### PR TITLE
Add appveyor support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
 build_script:
     - npm run build
     # Validate binary
-    - lib/bs/native/gentype.native --help
+    - lib\bs\native\gentype.native --help
 
 artifacts:
     - path: lib/bs/native/gentype.native

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+image: Visual Studio 2017
+
+platform:
+    - x64
+
+cache:
+    - node_modules
+
+install:
+    # The x64 is required as a workaround for esy/esy#412
+    - ps: Install-Product node 10 x64
+    - npm install
+
+build_script:
+    - npm run build
+    # Validate binary
+    - lib/bs/native/gentype.native --help
+
+artifacts:
+    - path: lib/bs/native/gentype.native
+      name: Windows Build
+      type: File

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,9 +14,9 @@ install:
 build_script:
     - npm run build
     # Validate binary
-    - lib\bs\native\gentype.native --help
+    - lib\bs\native\gentype.native.exe --help
 
 artifacts:
-    - path: lib/bs/native/gentype.native
+    - path: lib/bs/native/gentype.native.exe
       name: Windows Build
       type: File

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
     "clean": "bsb -clean-world"
   },
   "dependencies": {
-    "bsb-native": "4.0.6"
+    "bsb-native": "^4.0.6"
   }
 }


### PR DESCRIPTION
This will make appveyor build a Windows compatible binary.
You need to register on app-veyor and add the genType repository... as soon as it's added it should do a successful windows build