### PR TITLE
npm version automation & test infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,18 @@ We prepared some examples to give you an idea on how to integrate `genType` in y
 - [untyped-react-example](examples/untyped-react-example/README.md)
 
 
-## Release Procedure for MacOS and Linux binaries
+## Manual Release Procedure for MacOS and Linux Binaries
 
-For now, this is a manual process to create `lib/gentype-macos.tar.gz` and  `lib/gentype-linux.tar.gz` on a Mac. The linux binaries are created using a docker container.
+All releases need to pass our integration test suite. We use `npm test` to run the tests, make sure this command passes to be able to build a release.
+
+You can create `lib/gentype-macos.tar.gz` and  `lib/gentype-linux.tar.gz` via our manual release procedure on a Mac. The linux binaries are created using a docker container.
 
 
 ```
 ./create-release.sh
 ```
+
+**Please note:**
+
+We use [CircleCI](https://circleci.com/gh/cristianoc/genType) and [Appveyor](https://ci.appveyor.com/project/ryyppy/gentype) to build and automatically release to Github. Your manually released binaries might be overwritten by the built artifacts from tagged triggered commit.
+

--- a/create-release.sh
+++ b/create-release.sh
@@ -1,9 +1,11 @@
+set -e
+
 # Cleanup
 rm -f lib/gentype-*.tar.gz
 
 # MacOS
 npm install
-npm run clean && npm run build
+npm run clean && npm run build && npm run test
 tar czvf lib/gentype-macos.tar.gz  -C lib/bs/native gentype.native
 
 

--- a/examples/reason-react-example/package-lock.json
+++ b/examples/reason-react-example/package-lock.json
@@ -2071,7 +2071,7 @@
     },
     "events": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
     },
@@ -3244,7 +3244,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -3445,7 +3445,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "kind-of": {
@@ -3969,7 +3969,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true
     },
@@ -5461,7 +5461,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,15 @@
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
+    "debug": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+      "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -24,6 +33,12 @@
       "requires": {
         "pend": "~1.2.0"
       }
+    },
+    "ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "dev": true
     },
     "pend": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,17 @@
     "start": "bsb -make-world -backend native -w",
     "build": "bsb -make-world -backend native",
     "clean": "bsb -clean-world",
+    "test": "node ./scripts/run_integration_tests.js",
     "install:examples": "(cd examples/reason-react-example && npm install) & (cd examples/typescript-react-example && npm install) & (cd examples/untyped-react-example && npm install)",
-    "build:examples": "(cd examples/reason-react-example && npm run clean && npm run build) & (cd examples/typescript-react-example && npm run clean && npm run build) & (cd examples/untyped-react-example && npm run clean && npm run build)"
+    "build:examples": "(cd examples/reason-react-example && npm run clean && npm run build) & (cd examples/typescript-react-example && npm run clean && npm run build) & (cd examples/untyped-react-example && npm run clean && npm run build)",
+    "preversion": "npm test",
+    "version": "node scripts/bump_version_module.js && git add -A src/",
+    "postversion": "git push && git push --tags"
   },
   "dependencies": {
     "bsb-native": "^4.0.6"
+  },
+  "devDependencies": {
+    "debug": "^4.1.0"
   }
 }

--- a/scripts/bump_version_module.js
+++ b/scripts/bump_version_module.js
@@ -1,0 +1,13 @@
+const fs = require("fs");
+const pjson = require("../package.json");
+const path = require("path");
+
+const targetFile = path.join(__dirname, "..", "src", "Version.re");
+
+const content = `
+/* CREATED BY genType/scripts/bump_version_module.js */
+/* DO NOT MODIFY BY HAND, WILL BE AUTOMATICALLY UPDATED BY npm version */
+let version = "${pjson.version}";
+`;
+
+fs.writeFileSync(targetFile, content, "utf8");

--- a/scripts/run_integration_tests.js
+++ b/scripts/run_integration_tests.js
@@ -1,0 +1,100 @@
+/*
+ This script is used for cross-platform installing & building the example projects and
+ checking the git diff of the examples directory.
+ 
+ In a successful test scenario, after building the example projects, there should not be any changed files.
+ (We check manually verified genType generated files in git, we consider diffs as regressions)
+*/
+
+const debug = require("debug")("IO");
+const fs = require("fs");
+const child_process = require("child_process");
+const path = require("path");
+
+const exampleDirPaths = [
+  "reason-react-example",
+  "typescript-react-example",
+  "untyped-react-example"
+].map(exampleName => path.join(__dirname, "..", "examples", exampleName));
+
+const genTypeFile = path.join(
+  __dirname,
+  "..",
+  "lib",
+  "bs",
+  "native",
+  "gentype.native"
+);
+
+/*
+Needed for wrapping the stdout pipe with a promise
+*/
+function wrappedExecFile(command, args, options) {
+  return new Promise((resolve, reject) => {
+    const child = child_process.execFile(
+      command,
+      args,
+      options,
+      (err, stdout, stderr) => {
+        if (err) {
+          debug(`${command} ${args.join(" ")} exited with ${err.code}`);
+          return reject(err.code);
+        }
+        debug(`${command} ${args.join(" ")} exited with 0`);
+        resolve(stdout);
+      }
+    );
+  });
+}
+
+async function installExamples() {
+  const tasks = exampleDirPaths.map(cwd => {
+    console.log(`${cwd}: npm install (takes a while)`);
+    return wrappedExecFile("npm", ["install"], { cwd });
+  });
+
+  return Promise.all(tasks);
+}
+
+async function buildExamples() {
+  const tasks = exampleDirPaths.map(cwd => {
+    console.log(`${cwd}: npm run build (takes a while)`);
+    return wrappedExecFile("npm", ["run", "build"], { cwd });
+  });
+
+  return Promise.all(tasks);
+}
+
+async function checkDiff() {
+  try {
+    console.log("Checking for changes in examples/");
+    await wrappedExecFile("git", ["diff-index", "HEAD", "examples"]);
+  } catch (code) {
+    console.error(
+      "Changed files detected in path examples/! Make sure genType is emitting the right code and commit the files to git"
+    );
+    process.exit(1);
+  }
+}
+
+async function checkSetup() {
+  if (!fs.existsSync(genTypeFile)) {
+      const filepath = path.relative(path.join(__dirname, ".."), genTypeFile);
+      throw new Error(`${filepath} does not exist. Use \`npm run build\` first!`);
+  }
+}
+
+async function main() {
+  try {
+    await checkSetup();
+    await installExamples();
+    await buildExamples();
+    await checkDiff();
+    console.log("Test successful!");
+  } catch (e) {
+    console.error(`Test failed unexpectly: ${e.message}`);
+    debug(e);
+  }
+}
+
+main();

--- a/src/GenType.re
+++ b/src/GenType.re
@@ -4,7 +4,7 @@
 
 open GenTypeCommon;
 
-let version = "0.17.0";
+let version = Version.version;
 
 let signFile = s => s;
 

--- a/src/Version.re
+++ b/src/Version.re
@@ -1,0 +1,4 @@
+
+/* CREATED BY genType/scripts/bump_version_module.js */
+/* DO NOT MODIFY BY HAND, WILL BE AUTOMATICALLY UPDATED BY npm version */
+let version = "0.17.0";


### PR DESCRIPTION
This PR introduces following changes:
* Add node script for running "integration tests",  which is building all examples from scratch and look for any git diffs
* Adds version hooks, which I need to manually test first
* Also integrates the tests to the `create-release.sh` script