### PR TITLE
Fix git diffing

### DIFF
--- a/examples/run_bsb.js
+++ b/examples/run_bsb.js
@@ -18,7 +18,7 @@ function genTypeNativePath() {
     return path.join(base, "gentype.native");
   }
 }
-console.log(process.env.PWD);
+
 process.env.BS_CMT_POST_PROCESS_CMD = genTypeNativePath();
 
 const input = (args = process.argv.slice(2));

--- a/examples/run_bsb.js
+++ b/examples/run_bsb.js
@@ -18,7 +18,7 @@ function genTypeNativePath() {
     return path.join(base, "gentype.native");
   }
 }
-
+console.log(process.env.PWD);
 process.env.BS_CMT_POST_PROCESS_CMD = genTypeNativePath();
 
 const input = (args = process.argv.slice(2));

--- a/examples/typescript-react-example/clean.js
+++ b/examples/typescript-react-example/clean.js
@@ -11,6 +11,8 @@ glob.glob("src/**/*.bs.js", function(er, files) {
   });
 });
 
+const isWindows = /^win/i.test(process.platform);
+
 child_process
-  .spawn("bsb", ["-clean-world"], { stdio: "inherit", stderr: "inherit" })
+  .spawn("bsb", ["-clean-world"], { stdio: "inherit", stderr: "inherit", shell: isWindows })
   .on("exit", code => process.exit(code));

--- a/scripts/run_integration_tests.js
+++ b/scripts/run_integration_tests.js
@@ -96,10 +96,11 @@ function cleanBuildExamples() {
 function checkDiff() {
   console.log("Checking for changes in examples/");
 
-  const output = child_process.execFileSync("git", ["diff", "examples"]);
+  const output = child_process.execFileSync("git", ["diff", "examples"], {
+    encoding: "utf8"
+  });
 
-  console.log(output.toString());
-
+  console.log(output);
   if (output.length > 0) {
     throw new Error(
       "Changed files detected in path examples/! Make sure genType is emitting the right code and commit the files to git" +

--- a/scripts/run_integration_tests.js
+++ b/scripts/run_integration_tests.js
@@ -61,13 +61,13 @@ function wrappedSpawn(command, args, options) {
 
 async function installExamples() {
   const tasks = exampleDirPaths.map(cwd => {
-    console.log(`${cwd}: npm install --production --no-save (takes a while)`);
+    console.log(`${cwd}: npm install --no-save (takes a while)`);
 
     // The npm command is not an executable, but a cmd script on Windows
     // Without the shell = true, Windows will not find the program and fail
     // with ENOENT
     const shell = isWindows ? true : false;
-    return wrappedSpawn("npm", ["install", "--production", "--no-save"], {
+    return wrappedSpawn("npm", ["install", "--no-save"], {
       cwd,
       shell
     });

--- a/scripts/run_integration_tests.js
+++ b/scripts/run_integration_tests.js
@@ -11,7 +11,9 @@ const fs = require("fs");
 const child_process = require("child_process");
 const path = require("path");
 const pjson = require("../package.json");
+const util = require('util');
 
+const execFile = require('util').promisify(child_process.execFile);
 const exampleDirPaths = [
   "reason-react-example",
   "typescript-react-example",
@@ -79,7 +81,7 @@ async function buildExamples() {
     console.log(`${cwd}: npm run build (takes a while)`);
 
     const shell = isWindows ? true : false;
-    await wrappedSpawn("npm", ["run", "build"], {
+    child_process.execFileSync("npm", ["run", "build"], {
       cwd,
       shell
     });
@@ -160,8 +162,8 @@ async function main() {
     await buildExamples();
 
     /* Git diffing is broken... we need a better way to test regressions */
-    // await checkDiff();
-    
+    await checkDiff();
+
     console.log("Test successful!");
   } catch (e) {
     console.error(`Test failed unexpectly: ${e.message}`);

--- a/scripts/run_integration_tests.js
+++ b/scripts/run_integration_tests.js
@@ -1,9 +1,9 @@
 /*
- This script is used for cross-platform installing & building the example projects and
- checking the git diff of the examples directory.
- 
- In a successful test scenario, after building the example projects, there should not be any changed files.
- (We check manually verified genType generated files in git, we consider diffs as regressions)
+This script is used for cross-platform installing & building the example projects and
+checking the git diff of the examples directory.
+
+In a successful test scenario, after building the example projects, there should not be any changed files.
+(We check manually verified genType generated files in git, we consider diffs as regressions)
 */
 
 const debug = require("debug")("IO");
@@ -11,9 +11,7 @@ const fs = require("fs");
 const child_process = require("child_process");
 const path = require("path");
 const pjson = require("../package.json");
-const util = require('util');
 
-const execFile = require('util').promisify(child_process.execFile);
 const exampleDirPaths = [
   "reason-react-example",
   "typescript-react-example",
@@ -36,7 +34,7 @@ const genTypeFile = getGenTypeFilePath();
 /*
 Needed for wrapping the stdout pipe with a promise
 */
-async function wrappedSpawn(command, args, options) {
+function wrappedSpawn(command, args, options) {
   return new Promise((resolve, reject) => {
     const child = child_process.spawn(command, args, {
       env: process.env,
@@ -46,14 +44,13 @@ async function wrappedSpawn(command, args, options) {
     child.stdout.pipe(process.stdout);
     child.stderr.pipe(process.stderr);
 
-    child.on("exit", (code) => {
-      if(code == 0) {
+    child.on("exit", code => {
+      if (code == 0) {
         resolve(code);
-      }
-      else {
+      } else {
         reject(code);
       }
-    })
+    });
 
     child.on("error", err => {
       console.error(`${command} ${args.join(" ")} exited with ${err.code}`);
@@ -70,17 +67,25 @@ async function installExamples() {
     // Without the shell = true, Windows will not find the program and fail
     // with ENOENT
     const shell = isWindows ? true : false;
-    return wrappedSpawn("npm", ["install", "--production", "--no-save"], { cwd, shell });
+    return wrappedSpawn("npm", ["install", "--production", "--no-save"], {
+      cwd,
+      shell
+    });
   });
 
   return Promise.all(tasks);
 }
 
-async function buildExamples() {
-  for (const cwd of exampleDirPaths) {
-    console.log(`${cwd}: npm run build (takes a while)`);
+function cleanBuildExamples() {
+  for (let i = 0; i < exampleDirPaths.length; i++) {
+    const cwd = exampleDirPaths[i];
+    console.log(`${cwd}: npm run clean && npm run build (takes a while)`);
 
     const shell = isWindows ? true : false;
+    child_process.execFileSync("npm", ["run", "clean"], {
+      cwd,
+      shell
+    });
     child_process.execFileSync("npm", ["run", "build"], {
       cwd,
       shell
@@ -88,41 +93,22 @@ async function buildExamples() {
   }
 }
 
-async function checkDiff() {
-  /* This function should definitely be rewritten in a cleaner way */
-  try {
-    console.log("Checking for changes in examples/");
-    const output = child_process.execFileSync(
-      "git",
-      [
-        "diff-index",
-        "--name-only",
-        "HEAD",
-        "--",
-        "examples/*.js",
-        "examples/*.re",
-        "examples/*.bs.js",
-        "examples/*.re.js",
-        "examples/*.ts"
-      ],
-      { encoding: "utf8" }
-    );
+function checkDiff() {
+  console.log("Checking for changes in examples/");
 
-    console.log(output);
+  const output = child_process.execFileSync("git", ["diff", "examples"]);
 
-    if (output.length > 0) {
-      throw new Error(output);
-    }
-  } catch (err) {
-    console.error(
-      "Changed files detected in path examples/! Make sure genType is emitting the right code and commit the files to git"
+  console.log(output.toString());
+
+  if (output.length > 0) {
+    throw new Error(
+      "Changed files detected in path examples/! Make sure genType is emitting the right code and commit the files to git" +
+        "\n"
     );
-    console.error(err.message);
-    process.exit(1);
   }
 }
 
-async function checkSetup() {
+function checkSetup() {
   console.log(`Check existing binary: ${genTypeFile}`);
   if (!fs.existsSync(genTypeFile)) {
     const filepath = path.relative(path.join(__dirname, ".."), genTypeFile);
@@ -148,7 +134,8 @@ async function checkSetup() {
 
   if (output.indexOf(pjson.version) === -1) {
     throw new Error(
-      `${path.basename(genTypeFile)} --version doesn't contain the version number of package.json` +
+      path.basename(genTypeFile) +
+        ` --version doesn't contain the version number of package.json` +
         `("${stripNewlines(output)}" should contain ${pjson.version})` +
         `- Run \`node scripts/bump_version_module.js\` and rebuild to sync version numbers`
     );
@@ -157,12 +144,12 @@ async function checkSetup() {
 
 async function main() {
   try {
-    await checkSetup();
+    checkSetup();
     await installExamples();
-    await buildExamples();
+    cleanBuildExamples();
 
     /* Git diffing is broken... we need a better way to test regressions */
-    await checkDiff();
+    checkDiff();
 
     console.log("Test successful!");
   } catch (e) {


### PR DESCRIPTION
Enables `git diff` which checks for regressions after cleaning & building all examples.

**Still in progress:**
- [x] Fix Windows `npm run clean` and `npm run build` problems ([CI](https://ci.appveyor.com/project/cristianoc/gentype/builds/19856474))