### PR TITLE
Add ReactShim and update bsconfig in typescript example.

### DIFF
--- a/examples/typescript-react-example/bsconfig.json
+++ b/examples/typescript-react-example/bsconfig.json
@@ -4,8 +4,10 @@
     "module": "es6",
     "importPath": "relative",
     "shims": {
+      "React": "ReactShim",
+      "ReactEvent": "ReactEvent",
       "ReasonPervasives": "ReasonPervasives",
-      "ReactEvent": "ReactEvent"
+      "ReasonReact": "ReactShim"
     },
     "debug": {
       "all": false

--- a/examples/typescript-react-example/src/shims/ReactShim.shim.ts
+++ b/examples/typescript-react-example/src/shims/ReactShim.shim.ts
@@ -1,0 +1,28 @@
+// tslint:disable-next-line:max-classes-per-file
+export abstract class reactElement {
+  protected opaque: unknown
+}
+// tslint:disable-next-line:max-classes-per-file
+export abstract class component {
+  protected opaque: unknown
+}
+// tslint:disable-next-line:max-classes-per-file
+export abstract class componentSpec {
+  protected opaque: unknown
+}
+// tslint:disable-next-line:max-classes-per-file
+export abstract class noRetainedProps {
+  protected opaque: unknown
+}
+// tslint:disable-next-line:max-classes-per-file
+export abstract class actionless {
+  protected opaque: unknown
+}
+// tslint:disable-next-line:max-classes-per-file
+export abstract class stateless {
+  protected opaque: unknown
+}
+// tslint:disable-next-line:max-classes-per-file
+export abstract class reactRef {
+  protected opaque: unknown
+}


### PR DESCRIPTION
Add ReactShim and update bsconfig in typescript example.
Resolve `Cannot find module './ReasonReact.gen'` error.
https://github.com/cristianoc/genType/issues/135#issuecomment-461609145