### PR TITLE
Work around issue with Flow and function components.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,6 @@
+# master
+- Make Flow type check function components.
+
 # 2.20.0
 - Add support for default export like in bucklescript: call the value "default".
 - Hooks: generate names analogous to those from ppx for the React developer tools.

--- a/examples/commonjs-react-example/src/Hooks.gen.js
+++ b/examples/commonjs-react-example/src/Hooks.gen.js
@@ -15,7 +15,10 @@ import type {reactElement as ReasonReact_reactElement} from '../src/shims/ReactS
 
 export type vehicle = {| +name: string |};
 
-const $$default: ({| +vehicle: vehicle |}) => ReasonReact_reactElement = function Hooks(Arg1: $any) {
+// Type annotated function components are not checked by Flow, but typeof() works.
+const $$default$$forTypeof = function (_: {| +vehicle: vehicle |}) : ReasonReact_reactElement { return null };
+
+const $$default: typeof($$default$$forTypeof) = function Hooks(Arg1: $any) {
   const result = HooksBS.default({vehicle:[Arg1.vehicle.name]});
   return result
 };;

--- a/examples/flow-react-example/src/Hooks.gen.js
+++ b/examples/flow-react-example/src/Hooks.gen.js
@@ -15,34 +15,52 @@ import type {reactElement as ReasonReact_reactElement} from '../src/shims/ReactS
 
 export type vehicle = {| +name: string |};
 
-export const $$default: ({| +vehicle: vehicle |}) => ReasonReact_reactElement = function Hooks(Arg1: $any) {
+// Type annotated function components are not checked by Flow, but typeof() works.
+const $$default$$forTypeof = function (_: {| +vehicle: vehicle |}) : ReasonReact_reactElement { return null };
+
+export const $$default: typeof($$default$$forTypeof) = function Hooks(Arg1: $any) {
   const result = HooksBS.default({vehicle:[Arg1.vehicle.name]});
   return result
 };
 
 export default $$default;
 
-export const anotherComponent: ({| +vehicle: vehicle |}) => ReasonReact_reactElement = function Hooks_anotherComponent(Arg1: $any) {
+// Type annotated function components are not checked by Flow, but typeof() works.
+const anotherComponent$$forTypeof = function (_: {| +vehicle: vehicle |}) : ReasonReact_reactElement { return null };
+
+export const anotherComponent: typeof(anotherComponent$$forTypeof) = function Hooks_anotherComponent(Arg1: $any) {
   const result = HooksBS.anotherComponent({vehicle:[Arg1.vehicle.name]});
   return result
 };
 
-export const Inner_make: ({| +vehicle: vehicle |}) => ReasonReact_reactElement = function Hooks_Inner(Arg1: $any) {
+// Type annotated function components are not checked by Flow, but typeof() works.
+const Inner_make$$forTypeof = function (_: {| +vehicle: vehicle |}) : ReasonReact_reactElement { return null };
+
+export const Inner_make: typeof(Inner_make$$forTypeof) = function Hooks_Inner(Arg1: $any) {
   const result = HooksBS.Inner[0]({vehicle:[Arg1.vehicle.name]});
   return result
 };
 
-export const Inner_anotherComponent: ({| +vehicle: vehicle |}) => ReasonReact_reactElement = function Hooks_Inner_anotherComponent(Arg1: $any) {
+// Type annotated function components are not checked by Flow, but typeof() works.
+const Inner_anotherComponent$$forTypeof = function (_: {| +vehicle: vehicle |}) : ReasonReact_reactElement { return null };
+
+export const Inner_anotherComponent: typeof(Inner_anotherComponent$$forTypeof) = function Hooks_Inner_anotherComponent(Arg1: $any) {
   const result = HooksBS.Inner[1]({vehicle:[Arg1.vehicle.name]});
   return result
 };
 
-export const Inner_Inner2_make: ({| +vehicle: vehicle |}) => ReasonReact_reactElement = function Hooks_Inner_Inner2(Arg1: $any) {
+// Type annotated function components are not checked by Flow, but typeof() works.
+const Inner_Inner2_make$$forTypeof = function (_: {| +vehicle: vehicle |}) : ReasonReact_reactElement { return null };
+
+export const Inner_Inner2_make: typeof(Inner_Inner2_make$$forTypeof) = function Hooks_Inner_Inner2(Arg1: $any) {
   const result = HooksBS.Inner[2][0]({vehicle:[Arg1.vehicle.name]});
   return result
 };
 
-export const Inner_Inner2_anotherComponent: ({| +vehicle: vehicle |}) => ReasonReact_reactElement = function Hooks_Inner_Inner2_anotherComponent(Arg1: $any) {
+// Type annotated function components are not checked by Flow, but typeof() works.
+const Inner_Inner2_anotherComponent$$forTypeof = function (_: {| +vehicle: vehicle |}) : ReasonReact_reactElement { return null };
+
+export const Inner_Inner2_anotherComponent: typeof(Inner_Inner2_anotherComponent$$forTypeof) = function Hooks_Inner_Inner2_anotherComponent(Arg1: $any) {
   const result = HooksBS.Inner[2][1]({vehicle:[Arg1.vehicle.name]});
   return result
 };

--- a/src/EmitJs.re
+++ b/src/EmitJs.re
@@ -620,12 +620,7 @@ let rec emitCodeItem =
     config.emitImportCurry = config.emitImportCurry || useCurry;
     (env, emitters);
 
-  | ExportValue({
-      originalName,
-      resolvedName,
-      type_,
-      valueAccessPath,
-    }) =>
+  | ExportValue({originalName, resolvedName, type_, valueAccessPath}) =>
     let nameGen = EmitText.newNameGen();
     let importPath =
       fileName
@@ -643,20 +638,24 @@ let rec emitCodeItem =
     let default = "default";
     let make = "make";
 
-    let isHook =
+    let hookType =
       switch (type_) {
       | Function({
-          argTypes: [Object(_)],
+          argTypes: [Object(_) as propsT],
           retType:
-            Ident({name: "ReasonReact_reactElement" | "React_reactElement"}),
+            Ident({name: "ReasonReact_reactElement" | "React_reactElement"}) as retT,
         }) =>
-        true
-      | _ => false
+        Some((propsT, retT))
+      | _ => None
       };
+    /* Work around Flow issue with function components.
+       If type annotated direcly, they are not checked. But typeof() works. */
+    let flowFunctionTypeWorkaround =
+      hookType != None && config.language == Flow;
 
     let converter =
       switch (converter) {
-      | FunctionC(functionC) when isHook =>
+      | FunctionC(functionC) when hookType != None =>
         let chopSuffix = suffix =>
           resolvedName == suffix ?
             "" :
@@ -677,6 +676,27 @@ let rec emitCodeItem =
       | _ => converter
       };
 
+    let name = originalName == default ? Runtime.default : resolvedName;
+    let hookNameForTypeof = name ++ "$$forTypeof";
+    let type_ =
+      flowFunctionTypeWorkaround ?
+        ident("typeof(" ++ hookNameForTypeof ++ ")") : type_;
+
+    let emitters =
+      switch (hookType) {
+      | Some((propsType, retType)) when flowFunctionTypeWorkaround =>
+        EmitType.emitHookTypeAsFunction(
+          ~config,
+          ~emitters,
+          ~name=hookNameForTypeof,
+          ~propsType,
+          ~retType,
+          ~retValue="null",
+          ~typeNameIsInterface,
+        )
+      | _ => emitters
+      };
+
     let emitters =
       (
         (fileNameBs |> ModuleName.toString)
@@ -694,7 +714,7 @@ let rec emitCodeItem =
       |> EmitType.emitExportConst(
            ~config,
            ~emitters,
-           ~name=originalName == default ? Runtime.default : resolvedName,
+           ~name,
            ~type_,
            ~typeNameIsInterface,
          );

--- a/src/EmitType.re
+++ b/src/EmitType.re
@@ -296,6 +296,28 @@ let ofType = (~config, ~typeNameIsInterface, ~type_, s) =>
   config.language == Untyped ?
     s : s ++ ": " ++ (type_ |> typeToString(~config, ~typeNameIsInterface));
 
+let emitHookTypeAsFunction =
+    (
+      ~config,
+      ~emitters,
+      ~name,
+      ~propsType,
+      ~retType,
+      ~retValue,
+      ~typeNameIsInterface,
+    ) =>
+  "// Type annotated function components are not checked by Flow, but typeof() works.\n"
+  ++ "const "
+  ++ name
+  ++ " = function ("
+  ++ ("_" |> ofType(~config, ~typeNameIsInterface, ~type_=propsType))
+  ++ ")"
+  ++ (" " |> ofType(~config, ~typeNameIsInterface, ~type_=retType))
+  ++ " { return "
+  ++ retValue
+  ++ " };"
+  |> Emitters.export(~emitters);
+
 let emitExportConst_ =
     (
       ~early,

--- a/src/EmitType.rei
+++ b/src/EmitType.rei
@@ -56,6 +56,18 @@ let emitExportType:
   ) =>
   Emitters.t;
 
+let emitHookTypeAsFunction:
+  (
+    ~config: config,
+    ~emitters: Emitters.t,
+    ~name: string,
+    ~propsType: type_,
+    ~retType: type_,
+    ~retValue: string,
+    ~typeNameIsInterface: string => bool
+  ) =>
+  Emitters.t;
+
 let emitImportTypeAs:
   (
     ~emitters: Emitters.t,


### PR DESCRIPTION
If a function component is type annotated, then it is not checked by Flow.
Work around this issue by defining an auxiliary wrapper function just to call typeof() on it. The wrapper function is not type annotated directly, but its parameters and return are.
This makes Flow type check function components.