### PR TITLE
Inline types

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,8 @@
 # master
 - Support import of function components.
+- Fix issue where only shallow conversion was generated for nested records defined in another file.
+- Opaque types are now generated only for type definitions annotated with [@genType.opaque].
+  Unknown types now are left unchanged, so type errors will indicate that shims need to be added.
 
 # 2.21.1
 - Fix parentheses in function components with Flow back-end.

--- a/examples/typescript-react-example/src/Opaque.bs.js
+++ b/examples/typescript-react-example/src/Opaque.bs.js
@@ -5,8 +5,13 @@ function noConversion(x) {
   return x;
 }
 
+function testConvertNestedRecordFromOtherFile(x) {
+  return x;
+}
+
 export {
   noConversion ,
+  testConvertNestedRecordFromOtherFile ,
   
 }
 /* No side effect */

--- a/examples/typescript-react-example/src/Opaque.gen.tsx
+++ b/examples/typescript-react-example/src/Opaque.gen.tsx
@@ -7,4 +7,8 @@ const OpaqueBS = require('./Opaque.bs');
 // tslint:disable-next-line:class-name
 export abstract class opaqueFromRecords { protected opaque!: any }; /* simulate opaque types */
 
+// tslint:disable-next-line:max-classes-per-file 
+// tslint:disable-next-line:class-name
+export abstract class pair { protected opaque!: any }; /* simulate opaque types */
+
 export const noConversion: (_1:opaqueFromRecords) => opaqueFromRecords = OpaqueBS.noConversion;

--- a/examples/typescript-react-example/src/Opaque.gen.tsx
+++ b/examples/typescript-react-example/src/Opaque.gen.tsx
@@ -7,7 +7,8 @@ const OpaqueBS = require('./Opaque.bs');
 // tslint:disable-next-line:class-name
 export abstract class opaqueFromRecords { protected opaque!: any }; /* simulate opaque types */
 
-// tslint:disable-next-line:interface-over-type-literal
-export type pair = [opaqueFromRecords, opaqueFromRecords];
+// tslint:disable-next-line:max-classes-per-file 
+// tslint:disable-next-line:class-name
+export abstract class pair { protected opaque!: any }; /* simulate opaque types */
 
 export const noConversion: (_1:opaqueFromRecords) => opaqueFromRecords = OpaqueBS.noConversion;

--- a/examples/typescript-react-example/src/Opaque.gen.tsx
+++ b/examples/typescript-react-example/src/Opaque.gen.tsx
@@ -3,6 +3,8 @@
 // tslint:disable-next-line:no-var-requires
 const OpaqueBS = require('./Opaque.bs');
 
+import {business as Records_business} from './Records.gen';
+
 // tslint:disable-next-line:max-classes-per-file 
 // tslint:disable-next-line:class-name
 export abstract class opaqueFromRecords { protected opaque!: any }; /* simulate opaque types */
@@ -11,3 +13,8 @@ export abstract class opaqueFromRecords { protected opaque!: any }; /* simulate 
 export type pair = [opaqueFromRecords, opaqueFromRecords];
 
 export const noConversion: (_1:opaqueFromRecords) => opaqueFromRecords = OpaqueBS.noConversion;
+
+export const testConvertNestedRecordFromOtherFile: (_1:Records_business) => Records_business = function (Arg1: any) {
+  const result = OpaqueBS.testConvertNestedRecordFromOtherFile([Arg1.name, (Arg1.owner == null ? undefined : [Arg1.owner.name, Arg1.owner.age, Arg1.owner.address]), Arg1.address]);
+  return {name:result[0], owner:(result[1] == null ? result[1] : {name:result[1][0], age:result[1][1], address:result[1][2]}), address:result[2]}
+};

--- a/examples/typescript-react-example/src/Opaque.gen.tsx
+++ b/examples/typescript-react-example/src/Opaque.gen.tsx
@@ -7,8 +7,7 @@ const OpaqueBS = require('./Opaque.bs');
 // tslint:disable-next-line:class-name
 export abstract class opaqueFromRecords { protected opaque!: any }; /* simulate opaque types */
 
-// tslint:disable-next-line:max-classes-per-file 
-// tslint:disable-next-line:class-name
-export abstract class pair { protected opaque!: any }; /* simulate opaque types */
+// tslint:disable-next-line:interface-over-type-literal
+export type pair = [opaqueFromRecords, opaqueFromRecords];
 
 export const noConversion: (_1:opaqueFromRecords) => opaqueFromRecords = OpaqueBS.noConversion;

--- a/examples/typescript-react-example/src/Opaque.re
+++ b/examples/typescript-react-example/src/Opaque.re
@@ -4,3 +4,6 @@ type opaqueFromRecords =
 
 [@genType]
 let noConversion = (x: opaqueFromRecords) => x;
+
+[@genType]
+type pair = (opaqueFromRecords, opaqueFromRecords);

--- a/examples/typescript-react-example/src/Opaque.re
+++ b/examples/typescript-react-example/src/Opaque.re
@@ -7,3 +7,6 @@ let noConversion = (x: opaqueFromRecords) => x;
 
 [@genType]
 type pair = (opaqueFromRecords, opaqueFromRecords);
+
+[@genType]
+let testConvertNestedRecordFromOtherFile = (x: Records.business) => x;

--- a/src/Converter.re
+++ b/src/Converter.re
@@ -215,8 +215,6 @@ let typeGetConverterNormalized =
         ),
       );
 
-    | Opaque => (IdentC, normalized_)
-
     | Option(t) =>
       let (tConverter, tNormalized) = t |> visit(~visited);
       (OptionC(tConverter), Option(tNormalized));
@@ -333,8 +331,7 @@ let typeGetConverterNormalized =
     circular^ != "" ? CircularC(circular^, converter) : converter;
   if (Debug.converter^) {
     logItem(
-      "Converter %s type0:%s converter:%s\n",
-      normalized == Opaque ? " opaque " : "",
+      "Converter type0:%s converter:%s\n",
       type0 |> EmitType.typeToString(~config, ~typeNameIsInterface),
       finalConverter |> toString,
     );

--- a/src/Converter.re
+++ b/src/Converter.re
@@ -235,7 +235,12 @@ let typeGetConverterNormalized =
                (name, optional == Mandatory ? converter : OptionC(converter))
              ),
         ),
-        normalized_ /* Record(   fieldsConverted   |> List.map(((field, (_, tNormalized))) =>        {...field, type_: tNormalized}      ), ) */,
+        Record(
+          fieldsConverted
+          |> List.map(((field, (_, tNormalized))) =>
+               {...field, type_: tNormalized}
+             ),
+        ),
       );
 
     | Tuple(innerTypes) =>

--- a/src/Converter.re
+++ b/src/Converter.re
@@ -204,6 +204,8 @@ let typeGetConverterNormalized =
         normalized_,
       )
 
+    | Opaque => (IdentC, normalized_)
+
     | Option(t) =>
       let (tConverter, tNormalized) = t |> visit(~visited);
       (OptionC(tConverter), tNormalized == None ? None : normalized_);

--- a/src/Converter.re
+++ b/src/Converter.re
@@ -156,7 +156,7 @@ let typeGetConverterNormalized =
       /* This case should only fire from withing a function */
       (IdentC, normalized_)
 
-    | Ident({isShim, name, typeArgs}) =>
+    | Ident({name, typeArgs}) =>
       if (visited |> StringSet.mem(name)) {
         circular := name;
         (IdentC, normalized_);

--- a/src/Converter.re
+++ b/src/Converter.re
@@ -130,7 +130,7 @@ let typeGetConverterNormalized =
     switch (type_) {
     | Array(t, _) =>
       let (tConverter, tNormalized) = t |> visit(~visited);
-      (ArrayC(tConverter), tNormalized == None ? None : normalized_);
+      (ArrayC(tConverter), tNormalized == Some(Opaque) ? tNormalized : normalized_);
 
     | Function({argTypes, retType, typeVars, uncurried, _}) =>
       let argConverters =
@@ -186,11 +186,11 @@ let typeGetConverterNormalized =
 
     | Null(t) =>
       let (tConverter, tNormalized) = t |> visit(~visited);
-      (NullableC(tConverter), tNormalized == None ? None : normalized_);
+      (NullableC(tConverter), tNormalized == Some(Opaque) ? tNormalized : normalized_);
 
     | Nullable(t) =>
       let (tConverter, tNormalized) = t |> visit(~visited);
-      (NullableC(tConverter), tNormalized == None ? None : normalized_);
+      (NullableC(tConverter), tNormalized == Some(Opaque) ? tNormalized : normalized_);
 
     | Object(_, fields) => (
         ObjectC(
@@ -211,11 +211,11 @@ let typeGetConverterNormalized =
 
     | Option(t) =>
       let (tConverter, tNormalized) = t |> visit(~visited);
-      (OptionC(tConverter), tNormalized == None ? None : normalized_);
+      (OptionC(tConverter), tNormalized == Some(Opaque) ? tNormalized : normalized_);
 
     | Promise(t) =>
       let (tConverter, tNormalized) = t |> visit(~visited);
-      (PromiseC(tConverter), tNormalized == None ? None : normalized_);
+      (PromiseC(tConverter), tNormalized == Some(Opaque) ? tNormalized : normalized_);
 
     | Record(fields) => (
         RecordC(
@@ -235,8 +235,8 @@ let typeGetConverterNormalized =
     | Tuple(innerTypes) =>
       let (innerConversions, normalizedList) =
         innerTypes |> List.map(visit(~visited)) |> List.split;
-      let innerHasNone = normalizedList |> List.mem(None);
-      (TupleC(innerConversions), innerHasNone ? None : normalized_);
+      let innerHasOpaque = normalizedList |> List.mem(Some(Opaque));
+      (TupleC(innerConversions), innerHasOpaque ? Some(Opaque) : normalized_);
 
     | TypeVar(_) => (IdentC, normalized_)
 

--- a/src/EmitJs.re
+++ b/src/EmitJs.re
@@ -116,7 +116,7 @@ let emitExportType =
     | (Some(opaque), _) => (opaque, optType)
     | (None, Some(type_)) =>
       let normalized = type_ |> typeGetNormalized;
-      normalized == Opaque ? (true, optType) : (false, Some(normalized));
+      (false, Some(normalized));
     | (None, None) => (false, None)
     };
   resolvedTypeName
@@ -1061,7 +1061,6 @@ let propagateAnnotationToSubTypes =
       | Object(_, fields)
       | Record(fields) =>
         fields |> List.iter(({type_, _}) => type_ |> visit)
-      | Opaque => ()
       | Option(t)
       | Null(t)
       | Nullable(t)

--- a/src/EmitJs.re
+++ b/src/EmitJs.re
@@ -116,7 +116,7 @@ let emitExportType =
     | (Some(opaque), _) => (opaque, optType)
     | (None, Some(type_)) =>
       let normalized = type_ |> typeGetNormalized;
-      normalized == None ? (true, optType) : (false, normalized);
+      normalized == Some(Opaque) ? (true, optType) : (false, normalized);
     | (None, None) => (false, None)
     };
   resolvedTypeName

--- a/src/EmitJs.re
+++ b/src/EmitJs.re
@@ -116,7 +116,7 @@ let emitExportType =
     | (Some(opaque), _) => (opaque, optType)
     | (None, Some(type_)) =>
       let normalized = type_ |> typeGetNormalized;
-      normalized == Some(Opaque) ? (true, optType) : (false, normalized);
+      normalized == Opaque ? (true, optType) : (false, Some(normalized));
     | (None, None) => (false, None)
     };
   resolvedTypeName
@@ -607,11 +607,7 @@ let rec emitCodeItem =
           when config.language == Untyped && config.propTypes =>
         fields
         |> List.map((field: field) => {
-             let type_ =
-               switch (field.type_ |> typeGetInlined) {
-               | Some(type1) => type1
-               | None => type_
-               };
+             let type_ = field.type_ |> typeGetInlined;
              {...field, type_};
            })
         |> EmitType.emitPropTypes(~config, ~name, ~emitters, ~indent)
@@ -838,18 +834,13 @@ let emitVariantTables = (~emitters, variantTables) => {
 };
 
 let typeGetInlined = (~config, ~exportTypeMap, type_) =>
-  switch (
-    type_
-    |> Converter.typeGetNormalized(
-         ~config,
-         ~inline=true,
-         ~lookupId=s => exportTypeMap |> StringMap.find(s),
-         ~typeNameIsInterface=_ => false,
-       )
-  ) {
-  | None => type_
-  | Some(type1) => type1
-  };
+  type_
+  |> Converter.typeGetNormalized(
+       ~config,
+       ~inline=true,
+       ~lookupId=s => exportTypeMap |> StringMap.find(s),
+       ~typeNameIsInterface=_ => false,
+     );
 
 /* Read the cmt file referenced in an import type,
    and recursively for the import types obtained from reading the cmt file. */

--- a/src/EmitJs.re
+++ b/src/EmitJs.re
@@ -1070,6 +1070,7 @@ let propagateAnnotationToSubTypes =
       | Object(_, fields)
       | Record(fields) =>
         fields |> List.iter(({type_, _}) => type_ |> visit)
+      | Opaque => ()
       | Option(t)
       | Null(t)
       | Nullable(t)

--- a/src/EmitType.re
+++ b/src/EmitType.re
@@ -145,6 +145,9 @@ let rec renderType =
       )
       ++ ")"
     }
+  | Opaque =>
+    mixedOrUnknown(~config)
+    |> renderType(~config, ~indent, ~typeNameIsInterface, ~inFunType)
   | Promise(type_) =>
     "Promise"
     ++ "<"
@@ -595,6 +598,7 @@ let emitPropTypes = (~config, ~emitters, ~indent, ~name, fields) => {
     | Ident(_)
     | Null(_)
     | Nullable(_)
+    | Opaque
     | Option(_)
     | Promise(_)
     | Tuple(_)

--- a/src/EmitType.re
+++ b/src/EmitType.re
@@ -145,9 +145,6 @@ let rec renderType =
       )
       ++ ")"
     }
-  | Opaque =>
-    mixedOrUnknown(~config)
-    |> renderType(~config, ~indent, ~typeNameIsInterface, ~inFunType)
   | Promise(type_) =>
     "Promise"
     ++ "<"
@@ -598,7 +595,6 @@ let emitPropTypes = (~config, ~emitters, ~indent, ~name, fields) => {
     | Ident(_)
     | Null(_)
     | Nullable(_)
-    | Opaque
     | Option(_)
     | Promise(_)
     | Tuple(_)

--- a/src/GenTypeCommon.re
+++ b/src/GenTypeCommon.re
@@ -54,6 +54,7 @@ type type_ =
   | Null(type_)
   | Nullable(type_)
   | Object(closedFlag, fields)
+  | Opaque
   | Option(type_)
   | Promise(type_)
   | Record(fields)
@@ -95,6 +96,7 @@ let typeIsObject = type_ =>
   | Null(_) => false
   | Nullable(_) => false
   | Object(_) => true
+  | Opaque => false
   | Option(_) => false
   | Promise(_) => true
   | Record(_) => true

--- a/src/GenTypeCommon.re
+++ b/src/GenTypeCommon.re
@@ -74,7 +74,6 @@ and function_ = {
   uncurried: bool,
 }
 and ident = {
-  isShim: bool,
   name: string,
   typeArgs: list(type_),
 }
@@ -141,8 +140,8 @@ let createVariant = (~noPayloads, ~payloads, ~polymorphic) => {
 let variantTable = (hash, ~toJS) =>
   (toJS ? "$$toJS" : "$$toRE") ++ string_of_int(hash);
 
-let ident = (~isShim=false, ~typeArgs=[], name) =>
-  Ident({isShim, name, typeArgs});
+let ident = (~typeArgs=[], name) =>
+  Ident({name, typeArgs});
 
 let mixedOrUnknown = (~config) =>
   ident(

--- a/src/GenTypeCommon.re
+++ b/src/GenTypeCommon.re
@@ -54,7 +54,6 @@ type type_ =
   | Null(type_)
   | Nullable(type_)
   | Object(closedFlag, fields)
-  | Opaque
   | Option(type_)
   | Promise(type_)
   | Record(fields)
@@ -96,7 +95,6 @@ let typeIsObject = type_ =>
   | Null(_) => false
   | Nullable(_) => false
   | Object(_) => true
-  | Opaque => false
   | Option(_) => false
   | Promise(_) => true
   | Record(_) => true

--- a/src/TranslateTypeExprFromTypes.re
+++ b/src/TranslateTypeExprFromTypes.re
@@ -327,10 +327,9 @@ let translateConstr =
     | Some(type_) => {dependencies: typeParamDeps, type_}
     | None =>
       let dep = path |> Dependencies.fromPath(~config, ~typeEnv);
-      let isShim = dep |> Dependencies.isShim(~config);
       {
         dependencies: [dep, ...typeParamDeps],
-        type_: Ident({isShim, name: dep |> depToString, typeArgs}),
+        type_: Ident({name: dep |> depToString, typeArgs}),
       };
     };
   };

--- a/src/TypeVars.re
+++ b/src/TypeVars.re
@@ -56,6 +56,7 @@ let rec substitute = (~f, type0) =>
       fields
       |> List.map(field => {...field, type_: field.type_ |> substitute(~f)}),
     )
+  | Opaque => Opaque
   | Option(type_) => Option(type_ |> substitute(~f))
   | Promise(type_) => Promise(type_ |> substitute(~f))
   | Record(fields) =>
@@ -103,7 +104,8 @@ let rec free_ = type0: StringSet.t =>
          StringSet.empty,
        )
   | Null(type_)
-  | Nullable(type_)
+  | Nullable(type_) => type_ |> free_
+  | Opaque => StringSet.empty
   | Option(type_)
   | Promise(type_) => type_ |> free_
   | Tuple(innerTypes) =>

--- a/src/TypeVars.re
+++ b/src/TypeVars.re
@@ -56,7 +56,6 @@ let rec substitute = (~f, type0) =>
       fields
       |> List.map(field => {...field, type_: field.type_ |> substitute(~f)}),
     )
-  | Opaque => Opaque
   | Option(type_) => Option(type_ |> substitute(~f))
   | Promise(type_) => Promise(type_ |> substitute(~f))
   | Record(fields) =>
@@ -105,7 +104,6 @@ let rec free_ = type0: StringSet.t =>
        )
   | Null(type_)
   | Nullable(type_) => type_ |> free_
-  | Opaque => StringSet.empty
   | Option(type_)
   | Promise(type_) => type_ |> free_
   | Tuple(innerTypes) =>


### PR DESCRIPTION
Revisit type normalization so inlining goes deep into types.
Remove the use of opaque types during normalization. Using opaque types for unknown types was not compatible with inlining (e.g. the type definition discovered later).