### PR TITLE
Apply object field mangling convention to named arguments in functions.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,7 @@
 # master
 - Don't delete generated files in case of type errors.
+- Apply object field mangling convention to named arguments in functions.
+  This gives a unified treatment for renaming of object fields, functions, and function components.
 
 # 2.23.0
 - Preserve case when importing from a lower-case file name.

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ type person = {
 type persons = array(person);
 ```
 
-### Renaming, @genType.as, and object marshaling convention.
+### Renaming, @genType.as, and object mangling convention.
 
 By default, entities with a given name are exported/imported with the same name. However, you might wish to change the appearence of the name on the JS side.
 For example, in case of a record field whose name is a keyword, such as `type`:
@@ -212,7 +212,7 @@ type shipment = {
 };
 ```
 
-Object field names follow bucklescript's marshaling convention:
+Object field names follow bucklescript's mangling convention:
 
 ```
 Remove trailing "__" if present.
@@ -232,7 +232,7 @@ type shipment = {
 
 or the equivalent ``` "type__": string```.
 
-Functions and function components also follow the marshaling convention for labeled arguments:
+Functions and function components also follow the mangling convention for labeled arguments:
 
 ```reason
 [@genType]
@@ -323,7 +323,7 @@ Since objects are immutable by default, their fields will be exported to readonl
 
 It is possible to mix object and option types, so for example the Reason type `{. "x":int, "y":option(string)}` exports to JS type `{x:number, ?y: string}`, requires no conversion, and allows option pattern matching on the Reason side.
 
-Object field names follow bucklescript's marshaling convention (so e.g. `_type` in Reason represents `type` in JS):
+Object field names follow bucklescript's mangling convention (so e.g. `_type` in Reason represents `type` in JS):
 
 ```
 Remove trailing "__" if present.
@@ -394,7 +394,7 @@ Function components are exported and imported exactly like normal functions. For
 let make = (~name) => React.string(name);
 ```
 
-For renaming, named arguments follow bucklescript's marshaling convention:
+For renaming, named arguments follow bucklescript's mangling convention:
 
 ```
 Remove trailing "__" if present.

--- a/README.md
+++ b/README.md
@@ -198,10 +198,10 @@ type person = {
 type persons = array(person);
 ```
 
-### Renaming and @genType.as
+### Renaming, @genType.as, and object marshaling convention.
 
 By default, entities with a given name are exported/imported with the same name. However, you might wish to change the appearence of the name on the JS side.
-For example, in the case of a Reason keyword, such as `type`:
+For example, in case of a record field whose name is a keyword, such as `type`:
 
 ```reason
 [@genType]
@@ -212,15 +212,46 @@ type shipment = {
 };
 ```
 
-Or in the case of components:
+Object field names follow bucklescript's marshaling convention:
+
+```
+Remove trailing "__" if present.
+Otherwise remove leading "_" when followed by an uppercase letter, or keyword.
+```
+
+This means that the analogous example with objects is:
 
 ```reason
 [@genType]
-let make =
+type shipment = {
+  .
+  "date": float,
+  "_type": string,
+};
+```
+
+or the equivalent ``` "type__": string```.
+
+Functions and function components also follow the marshaling convention for labeled arguments:
+
+```reason
+[@genType]
+let exampleFunction = (~_type) => "type: " ++ _type;
+
+[@genType]
+[@react.component]
+let exampleComponent = (~_type) => React.string("type: " ++ _type);
+```
+
+It is possible to use `@genType.as` for functions, though this is only maintained for backwards compatibility, and cannot be used on function components:
+
+```reason
+[@genType]
+let functionWithGenTypeAs =
   (~date: float) => [@genType.as "type"] (~type_: string) => ...
 ```
 
-**NOTE** For technical reasons, it is not possible to rename the first argument of a function (it will be fixed once bucklescript supports OCaml 4.0.6).
+**NOTE** For technical reasons, it is not possible to use `g@enType.as` on the first argument of a function (restriction lifted on OCaml 4.0.6).
 
 
 ## Configuration
@@ -292,6 +323,14 @@ Since objects are immutable by default, their fields will be exported to readonl
 
 It is possible to mix object and option types, so for example the Reason type `{. "x":int, "y":option(string)}` exports to JS type `{x:number, ?y: string}`, requires no conversion, and allows option pattern matching on the Reason side.
 
+Object field names follow bucklescript's marshaling convention (so e.g. `_type` in Reason represents `type` in JS):
+
+```
+Remove trailing "__" if present.
+Otherwise remove leading "_" when followed by an uppercase letter, or keyword.
+```
+
+
 ### tuples
 
 Reason tuple values of type e.g. `(int, string)` are exported as identical JS values of type `[number, string]`. This requires no conversion, unless one of types of the tuple items does.
@@ -338,7 +377,7 @@ Immutable arrays are supported with the additional Reason library
 [ImmutableArray.re/.rei](examples/typescript-react-example/src/ImmutableArray.rei), which currently needs to be added to your project.
 The type `ImmutableArray.t(+'a)` is covariant, and is mapped to readonly array types in TS/Flow. As opposed to TS/Flow, `ImmutableArray.t` does not allow casting in either direction with normal arrays. Instead, a copy must be performed using `fromArray` and `toArray`.
 
-### functions
+### functions and function components
 
 Reason functions are exported as JS functions of the corresponding type.
 So for example a Reason function `foo : int => int` is exported as a JS function from numbers to numbers.
@@ -347,19 +386,31 @@ If named arguments are present in the Reason type, they are grouped and exported
 
 In case of mixed named and unnamed arguments, consecutive named arguments form separate groups. So e.g. `foo : (int, ~x:int, ~y:int, int, ~z:int) => int` is exported to a JS function of type `(number, {x:number, y:number}, number, {z:number}) => number`.
 
-To specify how a named argument is exported to JS, use the `[@genType.as "name"]` annotation:
+Function components are exported and imported exactly like normal functions. For example:
+
+```reaspn
+[@genType]
+[@react.component]
+let make = (~name) => React.string(name);
+```
+
+For renaming, named arguments follow bucklescript's marshaling convention:
+
+```
+Remove trailing "__" if present.
+Otherwise remove leading "_" when followed by an uppercase letter, or keyword.
+```
+
+For example:
 
 ```reason
 [@genType]
-let make =
-  (~date: float) => [@genType.as "type"] (~type_: string) => ...
+let exampleFunction = (~_type) => "type: " ++ _type;
 ```
 
-**NOTE** For technical reasons, it is not possible to rename the first argument of a function (it will be fixed once bucklescript supports OCaml 4.0.6).
+### record components
 
-### components
-
-ReasonReact components with props of Reason types `t1`, `t2`, `t3` are exported as reactjs components with props of the JS types corresponding to `t1`, `t2`, `t3`. The annotation is on the `make` function: `[@genType] let make ...`.
+ReasonReact record components with props of Reason types `t1`, `t2`, `t3` are exported as reactjs components with props of the JS types corresponding to `t1`, `t2`, `t3`. The annotation is on the `make` function: `[@genType] let make ...`.
 
 A file can export many components by defining them in sub-modules. The toplevel component is also exported as default.
 

--- a/examples/typescript-react-example/src/Hooks.bs.js
+++ b/examples/typescript-react-example/src/Hooks.bs.js
@@ -62,11 +62,25 @@ var Inner = /* module */[
   /* Inner2 */Inner2
 ];
 
+function functionWithRenamedArgs(_to, _Type, param) {
+  return _to[/* name */0] + _Type[/* name */0];
+}
+
+function Hooks$componentWithRenamedArgs(Props) {
+  var _to = Props.to;
+  var _Type = Props.Type;
+  return (function (param) {
+      return _to[/* name */0] + _Type[/* name */0];
+    });
+}
+
 var make = Hooks;
 
 var $$default = Hooks;
 
 var anotherComponent = Hooks$anotherComponent;
+
+var componentWithRenamedArgs = Hooks$componentWithRenamedArgs;
 
 export {
   make ,
@@ -74,6 +88,8 @@ export {
   $$default as default,
   anotherComponent ,
   Inner ,
+  functionWithRenamedArgs ,
+  componentWithRenamedArgs ,
   
 }
 /* react Not a pure module */

--- a/examples/typescript-react-example/src/Hooks.gen.tsx
+++ b/examples/typescript-react-example/src/Hooks.gen.tsx
@@ -3,12 +3,20 @@
 
 
 // tslint:disable-next-line:no-var-requires
+const Curry = require('bs-platform/lib/es6/curry.js');
+
+// tslint:disable-next-line:no-var-requires
 const HooksBS = require('./Hooks.bs');
+
+import {element as React_element} from '../src/shims/ReactShim.shim';
 
 import {reactElement as ReasonReact_reactElement} from '../src/shims/ReactShim.shim';
 
 // tslint:disable-next-line:interface-over-type-literal
 export type vehicle = { readonly name: string };
+
+// tslint:disable-next-line:interface-over-type-literal
+export type cb = (_1:{ readonly to: vehicle }) => void;
 
 export const $$default: (_1:{ readonly vehicle: vehicle }) => ReasonReact_reactElement = function Hooks(Arg1: any) {
   const result = HooksBS.default({vehicle:[Arg1.vehicle.name]});
@@ -39,5 +47,21 @@ export const Inner_Inner2_make: (_1:{ readonly vehicle: vehicle }) => ReasonReac
 
 export const Inner_Inner2_anotherComponent: (_1:{ readonly vehicle: vehicle }) => ReasonReact_reactElement = function Hooks_Inner_Inner2_anotherComponent(Arg1: any) {
   const result = HooksBS.Inner[2][1]({vehicle:[Arg1.vehicle.name]});
+  return result
+};
+
+export const functionWithRenamedArgs: (_1:{ readonly to: vehicle; readonly Type: vehicle }, _2:cb) => string = function (Arg1: any, Arg2: any) {
+  const result = Curry._3(HooksBS.functionWithRenamedArgs, [Arg1.to.name], [Arg1.Type.name], function (Argto: any) {
+      const result1 = Arg2({to:{name:Argto[0]}});
+      return result1
+    });
+  return result
+};
+
+export const componentWithRenamedArgs: (_1:{ readonly Type: vehicle; readonly to: vehicle }, _2:cb) => React_element = function (Arg1: any, Arg2: any) {
+  const result = Curry._2(HooksBS.componentWithRenamedArgs, {Type:[Arg1.Type.name], to:[Arg1.to.name]}, function (Argto: any) {
+      const result1 = Arg2({to:{name:Argto[0]}});
+      return result1
+    });
   return result
 };

--- a/examples/typescript-react-example/src/Hooks.re
+++ b/examples/typescript-react-example/src/Hooks.re
@@ -55,3 +55,14 @@ module Inner = {
       <div> {React.string("Another Hook " ++ vehicle.name)} </div>;
   };
 };
+
+[@genType]
+type cb = (~_to: vehicle) => unit;
+
+[@genType]
+let functionWithRenamedArgs = (~_to, ~_Type, _: cb) => _to.name ++ _Type.name;
+
+[@genType]
+[@react.component]
+let componentWithRenamedArgs = (~_to, ~_Type, _: cb) =>
+  React.string(_to.name ++ _Type.name);

--- a/src/Runtime.re
+++ b/src/Runtime.re
@@ -110,7 +110,7 @@ let checkMutableObjectField = (~previousName, ~name) =>
 
 let default = "$$default";
 
-module Marshal = {
+module Mangle = {
   let keywords = [|
     "and",
     "as",
@@ -200,4 +200,4 @@ module Marshal = {
   };
 };
 
-let marshalObjectField = Marshal.translate;
+let mangleObjectField = Mangle.translate;

--- a/src/Runtime.rei
+++ b/src/Runtime.rei
@@ -42,7 +42,7 @@ let emitVariantWithPayload:
 
 let isMutableObjectField: string => bool;
 
-let marshalObjectField : string => string;
+let mangleObjectField : string => string;
 
 let moduleItemGen: unit => moduleItemGen;
 

--- a/src/TranslateCoreType.re
+++ b/src/TranslateCoreType.re
@@ -107,7 +107,7 @@ let rec translateArrowType =
            ~revArgs=[
              (
                Label(
-                 asLabel == "" ? label |> Runtime.marshalObjectField : asLabel,
+                 asLabel == "" ? label |> Runtime.mangleObjectField : asLabel,
                ),
                type1,
              ),
@@ -128,7 +128,7 @@ let rec translateArrowType =
            ~revArgs=[
              (
                OptLabel(
-                 asLabel == "" ? lbl |> Runtime.marshalObjectField : asLabel,
+                 asLabel == "" ? lbl |> Runtime.mangleObjectField : asLabel,
                ),
                type1,
              ),

--- a/src/TranslateCoreType.re
+++ b/src/TranslateCoreType.re
@@ -105,7 +105,12 @@ let rec translateArrowType =
            ~typeEnv,
            ~revArgDeps=nextRevDeps,
            ~revArgs=[
-             (Label(asLabel == "" ? label : asLabel), type1),
+             (
+               Label(
+                 asLabel == "" ? label |> Runtime.marshalObjectField : asLabel,
+               ),
+               type1,
+             ),
              ...revArgs,
            ],
          );
@@ -121,7 +126,12 @@ let rec translateArrowType =
            ~typeEnv,
            ~revArgDeps=nextRevDeps,
            ~revArgs=[
-             (OptLabel(asLabel == "" ? lbl : asLabel), type1),
+             (
+               OptLabel(
+                 asLabel == "" ? lbl |> Runtime.marshalObjectField : asLabel,
+               ),
+               type1,
+             ),
              ...revArgs,
            ],
          );

--- a/src/TranslateTypeExprFromTypes.re
+++ b/src/TranslateTypeExprFromTypes.re
@@ -421,7 +421,10 @@ let rec translateArrowType =
            ~noFunctionReturnDependencies,
            ~typeEnv,
            ~revArgDeps=nextRevDeps,
-           ~revArgs=[(Label(label), type1), ...revArgs],
+           ~revArgs=[
+             (Label(label |> Runtime.marshalObjectField), type1),
+             ...revArgs,
+           ],
          );
     | Some((lbl, t1)) =>
       let {dependencies, type_: type1} =
@@ -434,7 +437,10 @@ let rec translateArrowType =
            ~noFunctionReturnDependencies,
            ~typeEnv,
            ~revArgDeps=nextRevDeps,
-           ~revArgs=[(OptLabel(lbl), type1), ...revArgs],
+           ~revArgs=[
+             (OptLabel(lbl |> Runtime.marshalObjectField), type1),
+             ...revArgs,
+           ],
          );
     }
   | _ =>

--- a/src/TranslateTypeExprFromTypes.re
+++ b/src/TranslateTypeExprFromTypes.re
@@ -310,7 +310,7 @@ let translateConstr =
              | Option(t) => (Optional, t)
              | _ => (Mandatory, t)
              };
-           let name = name |> Runtime.marshalObjectField;
+           let name = name |> Runtime.mangleObjectField;
            {mutable_, name, optional, type_};
          });
     let type_ = Object(closedFlag, fields);
@@ -422,7 +422,7 @@ let rec translateArrowType =
            ~typeEnv,
            ~revArgDeps=nextRevDeps,
            ~revArgs=[
-             (Label(label |> Runtime.marshalObjectField), type1),
+             (Label(label |> Runtime.mangleObjectField), type1),
              ...revArgs,
            ],
          );
@@ -438,7 +438,7 @@ let rec translateArrowType =
            ~typeEnv,
            ~revArgDeps=nextRevDeps,
            ~revArgs=[
-             (OptLabel(lbl |> Runtime.marshalObjectField), type1),
+             (OptLabel(lbl |> Runtime.mangleObjectField), type1),
              ...revArgs,
            ],
          );


### PR DESCRIPTION
This gives unified support for renaming on normal functions with named arguments, and function components.

Related: https://github.com/cristianoc/genType/issues/194.