### PR TITLE
Don't generate conversion for callbacks of type unit => ..., as it's unnecessary from bucklescript 5.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,9 @@
 - Fix issue where direct type declarations of uncurried types were not recognized.
   Inferred uncurried types or declarations inside other types were working already.
 - With untyped back-end, don't add type parameters to generated functions.
+- Don't generate conversion for callbacks of type unit => ..., as it's unnecessary from bucklescript 5.
+  Before bucklescript version 5, passing a function with arity 0 from JS would give a runtime error,
+  so a conversion was used to avoid this, adding runtime cost.
 
 # 2.28.0
 - Make core react types builtin instead of requiring a shim file.

--- a/examples/flow-react-example/src/Hooks.gen.js
+++ b/examples/flow-react-example/src/Hooks.gen.js
@@ -37,10 +37,7 @@ export default $$default;
 const anotherComponent$$forTypeof = function (_: {| +callback: ((void) => void), +vehicle: vehicle |}) : React$Node { return null };
 
 export const anotherComponent: typeof(anotherComponent$$forTypeof) = function Hooks_anotherComponent(Arg1: $any) {
-  const result = HooksBS.anotherComponent({callback:function (Arg11: $any) {
-      const result1 = Arg1.callback(Arg11);
-      return result1
-    }, vehicle:[Arg1.vehicle.name]});
+  const result = HooksBS.anotherComponent({callback:Arg1.callback, vehicle:[Arg1.vehicle.name]});
   return result
 };
 

--- a/examples/flow-react-example/src/Types.gen.js
+++ b/examples/flow-react-example/src/Types.gen.js
@@ -135,16 +135,7 @@ export const testAutoAnnotateVariants2: (AutoAnnotate_annotatedVariant) => AutoA
     : {tag:"R4", value:result[0]}
 };
 
-export const convertObjectWithCallback: (objectWithCallback) => objectWithCallback = function (Arg1: $any) {
-  const result = TypesBS.convertObjectWithCallback({y:(Arg1.y == null ? undefined : {z:(Arg1.y.z == null ? undefined : function (Arg11: $any) {
-      const result1 = Arg1.y.z(Arg11);
-      return result1
-    })}), x:(Arg1.x == null ? undefined : function (Arg12: $any) {
-      const result2 = Arg1.x(Arg12);
-      return result2
-    })});
-  return result
-};
+export const convertObjectWithCallback: (objectWithCallback) => objectWithCallback = TypesBS.convertObjectWithCallback;
 
 export const testInstantiateTypeParameter: (instantiateTypeParameter) => instantiateTypeParameter = function (Arg1: $any) {
   const result = TypesBS.testInstantiateTypeParameter(Arg1.map(function _element(ArrayItem: $any) { return [ArrayItem.id]}));

--- a/examples/typescript-react-example/src/Hooks.gen.tsx
+++ b/examples/typescript-react-example/src/Hooks.gen.tsx
@@ -31,10 +31,7 @@ export const $$default: (_1:{ readonly vehicle: vehicle }) => JSX.Element = func
 export default $$default;
 
 export const anotherComponent: (_1:{ readonly callback: ((_1:void) => void); readonly vehicle: vehicle }) => JSX.Element = function Hooks_anotherComponent(Arg1: any) {
-  const result = HooksBS.anotherComponent({callback:function (Arg11: any) {
-      const result1 = Arg1.callback(Arg11);
-      return result1
-    }, vehicle:[Arg1.vehicle.name]});
+  const result = HooksBS.anotherComponent({callback:Arg1.callback, vehicle:[Arg1.vehicle.name]});
   return result
 };
 

--- a/examples/typescript-react-example/src/Uncurried.gen.tsx
+++ b/examples/typescript-react-example/src/Uncurried.gen.tsx
@@ -39,19 +39,10 @@ export const curried3: (_1:number, _2:string, _3:number) => string = function (A
   return result
 };
 
-export const callback: (_1:((_1:void) => number)) => string = function (Arg1: any) {
-  const result = UncurriedBS.callback(function (Arg11: any) {
-      const result1 = Arg1(Arg11);
-      return result1
-    });
-  return result
-};
+export const callback: (_1:((_1:void) => number)) => string = UncurriedBS.callback;
 
 export const callback2: (_1:auth) => string = function (Arg1: any) {
-  const result = UncurriedBS.callback2([function (Arg11: any) {
-      const result1 = Arg1.login(Arg11);
-      return result1
-    }]);
+  const result = UncurriedBS.callback2([Arg1.login]);
   return result
 };
 

--- a/examples/untyped-react-example/src/App.gen.js
+++ b/examples/untyped-react-example/src/App.gen.js
@@ -11,10 +11,7 @@ import * as ReasonReact from 'reason-react/src/ReasonReact.js';
 export const App = ReasonReact.wrapReasonForJs(
   AppBS.component,
   (function _(jsProps) {
-     return Curry._5(AppBS.make, jsProps.array, (jsProps.callback == null ? undefined : function (Arg1) {
-  const result = jsProps.callback(Arg1);
-  return result
-}), [jsProps.person.name, jsProps.person.age, jsProps.person.optional, jsProps.person.unknown], jsProps.title, jsProps.children);
+     return Curry._5(AppBS.make, jsProps.array, jsProps.callback, [jsProps.person.name, jsProps.person.age, jsProps.person.optional, jsProps.person.unknown], jsProps.title, jsProps.children);
   }));
 
 App.propTypes = {

--- a/examples/untyped-react-example/src/main.js
+++ b/examples/untyped-react-example/src/main.js
@@ -19,8 +19,15 @@ printVariantWithPayload(testWithPayload({ x: 15 }));
 
 const Main = () => (
   <div>
-    <App title={"hello"} person={{ name: "Josh", age: 33 }} array={["abc"]} />
-    <Hooks vehicle={{name:"auto"}} />
+    <App
+      title={"hello"}
+      person={{ name: "Josh", age: 33 }}
+      array={["abc"]}
+      callback={() => {
+        console.log("callback called");
+      }}
+    />
+    <Hooks vehicle={{ name: "auto" }} />
   </div>
 );
 

--- a/src/Converter.re
+++ b/src/Converter.re
@@ -15,7 +15,6 @@ type t =
 and groupedArgConverter =
   | ArgConverter(t)
   | GroupConverter(list((string, optional, t)))
-  | UnitConverter
 and fieldsC = list((string, t))
 and functionC = {
   argConverters: list(groupedArgConverter),
@@ -60,7 +59,6 @@ let rec toString = converter =>
                |> String.concat(", ")
              )
              ++ "|}"
-           | UnitConverter => "unit"
            }
          )
       |> String.concat(", ")
@@ -330,8 +328,7 @@ let typeGetConverterNormalized =
       (converter, tNormalized);
     | _ =>
       let (converter, tNormalized) = type_ |> visit(~visited);
-      let converter =
-        type_ == unitT ? UnitConverter : ArgConverter(converter);
+      let converter = ArgConverter(converter);
       (converter, tNormalized);
     };
 
@@ -385,7 +382,6 @@ let rec converterIsIdentity = (~toJS, converter) =>
          | ArgConverter(argConverter) =>
            argConverter |> converterIsIdentity(~toJS=!toJS)
          | GroupConverter(_) => false
-         | UnitConverter => uncurried || toJS
          }
        )
 
@@ -554,9 +550,6 @@ let rec apply =
             |> String.concat(", ");
           (varNames, ["{" ++ fieldValues ++ "}"]);
         };
-      | UnitConverter =>
-        let varName = i + 1 |> EmitText.argi(~nameGen);
-        ([varName], [varName]);
       };
 
     let mkBody = bodyArgs => {


### PR DESCRIPTION
Don't generate conversion for callbacks of type unit => ..., as it's unnecessary from bucklescript 5.
  Before bucklescript version 5, passing a function with arity 0 from JS would give a runtime error,
  so a conversion was used to avoid this, adding runtime cost.