### PR TITLE
TypeScript: support importing a functional component declared with ty…

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,6 @@
+# master
+- TypeScript: support importing a functional component declared with type React.FC<...>.
+
 # 2.29.0
 - Fix issue where direct type declarations of uncurried types were not recognized.
   Inferred uncurried types or declarations inside other types were working already.

--- a/examples/typescript-react-example/src/ImportHookDefault.gen.tsx
+++ b/examples/typescript-react-example/src/ImportHookDefault.gen.tsx
@@ -5,13 +5,13 @@
 import {default as makeNotChecked} from './hookExample';
 
 // In case of type error, check the type of 'make' in 'ImportHookDefault.re' and './hookExample'.
-export const makeTypeChecked: (_1:{ readonly person: person; readonly children: JSX.Element }) => JSX.Element = makeNotChecked;
+export const makeTypeChecked: React.FC<{ readonly person: person; readonly children: JSX.Element }> = makeNotChecked;
 
 // Export 'make' early to allow circular import from the '.bs.js' file.
 export const make: unknown = function hookExample(Arg1: any) {
   const result = makeTypeChecked({person:{name:Arg1.person[0], age:Arg1.person[1]}, children:Arg1.children});
   return result
-} as (_1:{ readonly person: person; readonly children: JSX.Element }) => JSX.Element;
+} as React.FC<{ readonly person: person; readonly children: JSX.Element }>;
 
 // tslint:disable-next-line:interface-over-type-literal
 export type person = { readonly name: string; readonly age: number };

--- a/examples/typescript-react-example/src/ImportHooks.gen.tsx
+++ b/examples/typescript-react-example/src/ImportHooks.gen.tsx
@@ -7,13 +7,13 @@ import {make as makeNotChecked} from './hookExample';
 import {foo as fooNotChecked} from './hookExample';
 
 // In case of type error, check the type of 'make' in 'ImportHooks.re' and './hookExample'.
-export const makeTypeChecked: (_1:{ readonly person: person; readonly children: JSX.Element }) => JSX.Element = makeNotChecked;
+export const makeTypeChecked: React.FC<{ readonly person: person; readonly children: JSX.Element }> = makeNotChecked;
 
 // Export 'make' early to allow circular import from the '.bs.js' file.
 export const make: unknown = function hookExample(Arg1: any) {
   const result = makeTypeChecked({person:{name:Arg1.person[0], age:Arg1.person[1]}, children:Arg1.children});
   return result
-} as (_1:{ readonly person: person; readonly children: JSX.Element }) => JSX.Element;
+} as React.FC<{ readonly person: person; readonly children: JSX.Element }>;
 
 // In case of type error, check the type of 'foo' in 'ImportHooks.re' and './hookExample'.
 export const fooTypeChecked: (_1:{ readonly person: person }) => string = fooNotChecked;

--- a/examples/typescript-react-example/src/hookExample.tsx
+++ b/examples/typescript-react-example/src/hookExample.tsx
@@ -4,10 +4,12 @@ export const foo = (x: {
   person: { readonly name: string; readonly age: number };
 }) => x.person.name;
 
-export const make = (x: {
+type Props = {
   readonly person: { readonly name: string; readonly age: number };
   readonly children: JSX.Element;
-}) => (
+};
+
+export const make: React.FC<Props> = (x: Props) => (
   <div>
     {" "}
     {x.person.name} {x.children}{" "}

--- a/src/EmitJs.re
+++ b/src/EmitJs.re
@@ -440,16 +440,19 @@ let rec emitCodeItem =
       };
     let converter = type_ |> typeGetConverter;
 
-    let isHook = () =>
+    let (isHook, type_) =
       switch (type_) {
-      | Function({argTypes: [Object(_)], retType})
+      | Function({argTypes: [Object(_) as propsType], retType})
           when retType |> EmitType.isTypeReactElement(~config) =>
-        true
-      | _ => false
+        let type_ =
+          config.language == TypeScript ?
+            EmitType.typeReactFunctionComponentTypeScript(~propsType) : type_;
+        (true, type_);
+      | _ => (false, type_)
       };
     let converter =
       switch (converter) {
-      | FunctionC(functionC) when isHook() =>
+      | FunctionC(functionC) when isHook =>
         Converter.FunctionC({...functionC, functionName: Some(importFile)})
       | _ => converter
       };

--- a/src/EmitType.re
+++ b/src/EmitType.re
@@ -639,6 +639,9 @@ let typeReactElementFlow = ident(~builtin=true, "React$Node");
 
 let typeReactElementTypeScript = ident(~builtin=true, "JSX.Element");
 
+let typeReactFunctionComponentTypeScript = (~propsType) =>
+  ident(~builtin=true, ~typeArgs=[propsType], "React.FC");
+
 let typeReactElement = (~config) =>
   config.language == Flow ? typeReactElementFlow : typeReactElementTypeScript;
 

--- a/src/EmitType.rei
+++ b/src/EmitType.rei
@@ -148,6 +148,8 @@ let shimExtension: (~config: config) => string;
 
 let typeReactComponent: (~config: config, ~propsTypeName: string) => type_;
 
+let typeReactFunctionComponentTypeScript: (~propsType: type_) => type_;
+
 let typeReactContext: (~config: config, ~type_: type_) => type_;
 
 let typeReactElement: (~config: config) => type_;


### PR DESCRIPTION
…pe React.FC<...>.

A value of function type has automatically type React.FC<...>, but the opposite conversion fails.

To support JS values typed with React.FC<...>, use the React.FC<...> type for the type check.