### PR TITLE
Support externals with different name: external foo: someType = "fooR…

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,6 @@
+# master
+- Support externals with different name: external foo: someType = "fooRenamed".
+
 # 2.30.0
 - TypeScript: represent all function components with type `React.FC<...>`.
   A function component is any value of type `props => React.element` where `props` has type object.  

--- a/examples/flow-react-example/src/ImportHooks.bs.js
+++ b/examples/flow-react-example/src/ImportHooks.bs.js
@@ -2,7 +2,7 @@
 
 import * as ImportHooksGen from "./ImportHooks.gen";
 
-var make = ImportHooksGen.make;
+var make = ImportHooksGen.makeRenamed;
 
 function foo(prim) {
   return ImportHooksGen.foo(prim);

--- a/examples/flow-react-example/src/ImportHooks.gen.js
+++ b/examples/flow-react-example/src/ImportHooks.gen.js
@@ -8,21 +8,21 @@
 type $any = any;
 
 // flowlint-next-line nonstrict-import:off
-import {make as makeNotChecked} from './hookExample';
+import {makeRenamed as makeRenamedNotChecked} from './hookExample';
 
 // flowlint-next-line nonstrict-import:off
 import {foo as fooNotChecked} from './hookExample';
 
-// In case of type error, check the type of 'make' in 'ImportHooks.re' and './hookExample'.
-export const makeTypeChecked: <a>({|
+// In case of type error, check the type of 'makeRenamed' in 'ImportHooks.re' and './hookExample'.
+export const makeRenamedTypeChecked: <a>({|
   +person: person, 
   +children: React$Node, 
   +renderMe: renderMe<a>
-|}) => React$Node = makeNotChecked;
+|}) => React$Node = makeRenamedNotChecked;
 
-// Export 'make' early to allow circular import from the '.bs.js' file.
-export const make: mixed = function hookExample<a>(Arg1: $any) {
-  const result = makeTypeChecked({person:{name:Arg1.person[0], age:Arg1.person[1]}, children:Arg1.children, renderMe:Arg1.renderMe});
+// Export 'makeRenamed' early to allow circular import from the '.bs.js' file.
+export const makeRenamed: mixed = function hookExample<a>(Arg1: $any) {
+  const result = makeRenamedTypeChecked({person:{name:Arg1.person[0], age:Arg1.person[1]}, children:Arg1.children, renderMe:Arg1.renderMe});
   return result
 };
 

--- a/examples/flow-react-example/src/ImportHooks.re
+++ b/examples/flow-react-example/src/ImportHooks.re
@@ -17,7 +17,7 @@ type renderMe('a) =
 external make:
   (~person: person, ~children: React.element, ~renderMe: renderMe('a)) =>
   React.element =
-  "make";
+  "makeRenamed";
 
 [@genType.import "./hookExample"]
 external foo: (~person: person) => string = "foo";

--- a/examples/flow-react-example/src/hookExample.js
+++ b/examples/flow-react-example/src/hookExample.js
@@ -9,6 +9,13 @@ export const foo = function(x: { +person: { +name: string, +age: number } }) {
 export const make = (x: {
   +person: { +name: string, +age: number },
   +children: React.Node
-}) => <div> {x.person.name} {x.children} </div>;
+}) => (
+  <div>
+    {" "}
+    {x.person.name} {x.children}{" "}
+  </div>
+);
 
-export default make
+export const makeRenamed = make;
+
+export default make;

--- a/examples/typescript-react-example/src/ImportHooks.bs.js
+++ b/examples/typescript-react-example/src/ImportHooks.bs.js
@@ -2,7 +2,7 @@
 
 import * as ImportHooksGen from "./ImportHooks.gen";
 
-var make = ImportHooksGen.make;
+var make = ImportHooksGen.makeRenamed;
 
 function foo(prim) {
   return ImportHooksGen.foo(prim);

--- a/examples/typescript-react-example/src/ImportHooks.gen.tsx
+++ b/examples/typescript-react-example/src/ImportHooks.gen.tsx
@@ -2,20 +2,20 @@
 /* eslint-disable import/first */
 
 
-import {make as makeNotChecked} from './hookExample';
+import {makeRenamed as makeRenamedNotChecked} from './hookExample';
 
 import {foo as fooNotChecked} from './hookExample';
 
-// In case of type error, check the type of 'make' in 'ImportHooks.re' and './hookExample'.
-export const makeTypeChecked: React.FC<{
+// In case of type error, check the type of 'makeRenamed' in 'ImportHooks.re' and './hookExample'.
+export const makeRenamedTypeChecked: React.FC<{
   readonly person: person; 
   readonly children: JSX.Element; 
   readonly renderMe: renderMe<any>
-}> = makeNotChecked;
+}> = makeRenamedNotChecked;
 
-// Export 'make' early to allow circular import from the '.bs.js' file.
-export const make: unknown = function hookExample<a>(Arg1: any) {
-  const result = makeTypeChecked({person:{name:Arg1.person[0], age:Arg1.person[1]}, children:Arg1.children, renderMe:Arg1.renderMe});
+// Export 'makeRenamed' early to allow circular import from the '.bs.js' file.
+export const makeRenamed: unknown = function hookExample<a>(Arg1: any) {
+  const result = makeRenamedTypeChecked({person:{name:Arg1.person[0], age:Arg1.person[1]}, children:Arg1.children, renderMe:Arg1.renderMe});
   return result
 } as React.FC<{
   readonly person: person; 

--- a/examples/typescript-react-example/src/ImportHooks.re
+++ b/examples/typescript-react-example/src/ImportHooks.re
@@ -17,7 +17,7 @@ type renderMe('a) =
 external make:
   (~person: person, ~children: React.element, ~renderMe: renderMe('a)) =>
   React.element =
-  "make";
+  "makeRenamed";
 
 [@genType.import "./hookExample"]
 external foo: (~person: person) => string = "foo";

--- a/examples/typescript-react-example/src/hookExample.tsx
+++ b/examples/typescript-react-example/src/hookExample.tsx
@@ -17,4 +17,6 @@ export const make: React.FC<Props> = (x: Props) => (
   </div>
 );
 
+export const makeRenamed = make;
+
 export default make;

--- a/src/Translation.re
+++ b/src/Translation.re
@@ -304,7 +304,15 @@ let translatePrimitive =
   if (Debug.translation^) {
     logItem("Translate Primitive\n");
   };
-  let valueName = valueDescription.val_id |> Ident.name;
+  let valueName =
+    switch (valueDescription.val_prim) {
+    | ["", ..._]
+    | [] => valueDescription.val_id |> Ident.name
+    | [nameOfExtern, ..._] =>
+      /* extern foo : someType = "abc"
+         The first element of val_prim is "abc" */
+      nameOfExtern
+    };
   let typeExprTranslation =
     valueDescription.val_desc
     |> TranslateCoreType.translateCoreType(~config, ~typeEnv);


### PR DESCRIPTION
…enamed".

Fixes https://github.com/cristianoc/genType/issues/215.