### PR TITLE
Fix issue where conversion functions are not be generated for types d…

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,6 @@
+# master
+- Fix issue where conversion functions are not be generated for types defined in other files when `"importPath": "node",` is set in `gentypeconfig`.
+
 # 2.31.1
 - Add support for default import when the value is called `default` in the external.
   ```[@genType.import "./MyMath"] external default: int = "default";```

--- a/src/EmitJs.re
+++ b/src/EmitJs.re
@@ -97,9 +97,9 @@ let codeItemToString = (~config, ~typeNameIsInterface, codeItem: CodeItem.t) =>
     ++ " type:"
     ++ EmitType.typeToString(~config, ~typeNameIsInterface, type_)
   | ImportComponent({importAnnotation, _}) =>
-    "ImportComponent " ++ (importAnnotation.importPath |> ImportPath.toString)
+    "ImportComponent " ++ (importAnnotation.importPath |> ImportPath.dump)
   | ImportValue({importAnnotation, _}) =>
-    "ImportValue " ++ (importAnnotation.importPath |> ImportPath.toString)
+    "ImportValue " ++ (importAnnotation.importPath |> ImportPath.dump)
   };
 
 let emitExportType =
@@ -325,7 +325,7 @@ let rec emitCodeItem =
                ++ (fileName |> ModuleName.toString)
                ++ ".re'"
                ++ " and the props of '"
-               ++ (importPath |> ImportPath.toString)
+               ++ (importPath |> ImportPath.emit(~config))
                ++ "'.",
            );
 
@@ -469,7 +469,7 @@ let rec emitCodeItem =
              ++ (fileName |> ModuleName.toString)
              ++ ".re'"
              ++ " and '"
-             ++ (importPath |> ImportPath.toString)
+             ++ (importPath |> ImportPath.emit(~config))
              ++ "'.",
            ~emitters,
            ~name=valueNameTypeChecked,
@@ -523,7 +523,6 @@ let rec emitCodeItem =
     let importPath =
       fileName
       |> ModuleResolver.resolveModule(
-           ~config,
            ~outputFileRelative,
            ~resolver,
            ~importExtension=".bs",
@@ -672,7 +671,6 @@ let rec emitCodeItem =
     let importPath =
       fileName
       |> ModuleResolver.resolveModule(
-           ~config,
            ~outputFileRelative,
            ~resolver,
            ~importExtension=".bs",

--- a/src/EmitType.re
+++ b/src/EmitType.re
@@ -578,7 +578,7 @@ let emitImportValueAsEarly = (~config, ~emitters, ~name, ~nameAs, importPath) =>
   )
   ++ " from "
   ++ "'"
-  ++ (importPath |> ImportPath.toString)
+  ++ (importPath |> ImportPath.emit(~config))
   ++ "';"
   |> Emitters.requireEarly(~emitters);
 };
@@ -608,7 +608,7 @@ let emitRequire =
     ++ "import * as "
     ++ ModuleName.toString(moduleName)
     ++ " from '"
-    ++ (importPath |> ImportPath.toString)
+    ++ (importPath |> ImportPath.emit(~config))
     ++ "';"
     |> (early ? Emitters.requireEarly : Emitters.require)(~emitters)
   | _ =>
@@ -616,7 +616,7 @@ let emitRequire =
     ++ "const "
     ++ ModuleName.toString(moduleName)
     ++ " = require('"
-    ++ (importPath |> ImportPath.toString)
+    ++ (importPath |> ImportPath.emit(~config))
     ++ "');"
     |> (early ? Emitters.requireEarly : Emitters.require)(~emitters)
   };
@@ -736,7 +736,7 @@ let emitImportTypeAs =
       }
     )
     ++ "} from '"
-    ++ (importPath |> ImportPath.toString)
+    ++ (importPath |> ImportPath.emit(~config))
     ++ "';"
     |> Emitters.import(~emitters)
   | Untyped => emitters

--- a/src/ImportPath.re
+++ b/src/ImportPath.re
@@ -1,35 +1,34 @@
 open GenTypeCommon;
 
-type t = string;
+type t = (string, string);
 
-let propTypes = "prop-types";
+let propTypes = ("", "prop-types");
 
-let react = "react";
-let reasonReactPath = (~config) => config.reasonReactPath;
-let bsBlockPath = Config_.getBsBlockPath;
+let react = ("", "react");
+let reasonReactPath = (~config) => ("", config.reasonReactPath);
+let bsBlockPath = (~config) => ("", Config_.getBsBlockPath(~config));
 
-let bsCurryPath = Config_.getBsCurryPath;
+let bsCurryPath = (~config) => ("", Config_.getBsCurryPath(~config));
 
-let fromModule = (~config, ~dir, ~importExtension, moduleName) => {
+let fromModule = (~dir, ~importExtension, moduleName) => {
   let withNoPath = (moduleName |> ModuleName.toString) ++ importExtension;
-  switch (config.importPath) {
-  | Relative => NodeFilename.concat(dir, withNoPath)
-  | Node => withNoPath
-  };
+  (dir, withNoPath);
 };
 
-let fromStringUnsafe = s => s;
+let fromStringUnsafe = s => ("", s);
 
 let chopExtensionSafe = s =>
   try (s |> Filename.chop_extension) {
   | Invalid_argument(_) => s
   };
 
-let toCmt = (~config, ~outputFileRelative, s) =>
+let dump = ((dir, s)) => NodeFilename.concat(dir, s);
+
+let toCmt = (~config, ~outputFileRelative, (dir, s)) =>
   Filename.(
     concat(
       outputFileRelative |> dirname,
-      (s |> chopExtensionSafe)
+      ((dir, s |> chopExtensionSafe) |> dump)
       ++ (
         switch (config.namespace) {
         | None => ""
@@ -39,4 +38,9 @@ let toCmt = (~config, ~outputFileRelative, s) =>
       ++ ".cmt",
     )
   );
-let toString = s => s;
+
+let emit = (~config, (dir, s)) =>
+  switch (config.importPath) {
+  | Relative => (dir, s) |> dump
+  | Node => s
+  };

--- a/src/ImportPath.rei
+++ b/src/ImportPath.rei
@@ -6,17 +6,16 @@ let bsBlockPath: (~config: config) => t;
 
 let bsCurryPath: (~config: config) => t;
 
-let fromModule:
-  (~config: config, ~dir: string, ~importExtension: string, ModuleName.t) => t;
+let dump: t => string;
+let emit: (~config: config, t) => string;
+let fromModule: (~dir: string, ~importExtension: string, ModuleName.t) => t;
 
 let fromStringUnsafe: string => t;
 
-let propTypes : t;
+let propTypes: t;
 
 let reasonReactPath: (~config: config) => t;
 
 let react: t;
 
 let toCmt: (~config: config, ~outputFileRelative: string, t) => string;
-
-let toString: t => string;

--- a/src/ImportPath.rei
+++ b/src/ImportPath.rei
@@ -7,7 +7,9 @@ let bsBlockPath: (~config: config) => t;
 let bsCurryPath: (~config: config) => t;
 
 let dump: t => string;
+
 let emit: (~config: config, t) => string;
+
 let fromModule: (~dir: string, ~importExtension: string, ModuleName.t) => t;
 
 let fromStringUnsafe: string => t;

--- a/src/ModuleResolver.re
+++ b/src/ModuleResolver.re
@@ -106,7 +106,7 @@ let apply = (~resolver, moduleName) =>
 /* Resolve a reference to ModuleName, and produce a path suitable for require.
    E.g. require "../foo/bar/ModuleName.ext" where ext is ".re" or ".js". */
 let resolveModule =
-    (~config, ~outputFileRelative, ~resolver, ~importExtension, moduleName) => {
+    (~outputFileRelative, ~resolver, ~importExtension, moduleName) => {
   open Filename;
 
   let outputFileRelativeDir =
@@ -120,7 +120,7 @@ let resolveModule =
   let candidate =
     /* e.g. import "./Modulename.ext" */
     moduleName
-    |> ImportPath.fromModule(~config, ~dir=current_dir_name, ~importExtension);
+    |> ImportPath.fromModule(~dir=current_dir_name, ~importExtension);
   if (Sys.file_exists(moduleNameReFile)) {
     candidate;
   } else {
@@ -153,7 +153,6 @@ let resolveModule =
       /* e.g. import "../dst/ModuleName.ext" */
       (case == Uppercase ? moduleName : moduleName |> ModuleName.uncapitalize)
       |> ImportPath.fromModule(
-           ~config,
            ~dir=fromOutputDirToModuleDir,
            ~importExtension,
          );
@@ -166,7 +165,7 @@ let resolveSourceModule = (~importPath, moduleName) => {
     logItem("Resolve Source Module: %s\n", moduleName |> ModuleName.toString);
   };
   if (Debug.moduleResolution^) {
-    logItem("Import Path: %s\n", importPath |> ImportPath.toString);
+    logItem("Import Path: %s\n", importPath |> ImportPath.dump);
   };
   importPath;
 };
@@ -181,14 +180,13 @@ let resolveGeneratedModule =
   };
   let importPath =
     resolveModule(
-      ~config,
       ~outputFileRelative,
       ~resolver,
       ~importExtension=EmitType.generatedModuleExtension(~config),
       moduleName,
     );
   if (Debug.moduleResolution^) {
-    logItem("Import Path: %s\n", importPath |> ImportPath.toString);
+    logItem("Import Path: %s\n", importPath |> ImportPath.dump);
   };
   importPath;
 };
@@ -208,14 +206,13 @@ let importPathForReasonModuleName =
     };
     let importPath =
       resolveModule(
-        ~config,
         ~outputFileRelative,
         ~resolver,
         ~importExtension=".shim",
         shimModuleName,
       );
     if (Debug.moduleResolution^) {
-      logItem("Import Path: %s\n", importPath |> ImportPath.toString);
+      logItem("Import Path: %s\n", importPath |> ImportPath.dump);
     };
     importPath;
   | exception Not_found =>


### PR DESCRIPTION
…efined in other files when `"importPath": "node",` is set in `gentypeconfig`.

Fixes https://github.com/cristianoc/genType/issues/223.

When `node` mode is set, no relative paths are output for import paths. However, the full path is required to find the corresponding .cmt file.