### PR TITLE
In TypeScript export children of Reason type `element` as TS type `Re…

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,8 @@
 # master
+- In TypeScript export children of Reason type `element` as TS type `React.ReactChild`.
+  So the exported component can be used from TS with string and number literals.
+
+# 2.36.0
 - Export Props type when exporting a function component.
 - Add support for exporting references as 1-tuples.
   There are some nuances when the argument type requires conversion: https://github.com/cristianoc/genType/issues/237.

--- a/examples/flow-react-example/src/Hooks.bs.js
+++ b/examples/flow-react-example/src/Hooks.bs.js
@@ -128,6 +128,12 @@ function Hooks$RenderPropRequiresConversion(Props) {
 
 var RenderPropRequiresConversion = /* module */[/* make */Hooks$RenderPropRequiresConversion];
 
+function Hooks$aComponentWithChildren(Props) {
+  var vehicle = Props.vehicle;
+  var children = Props.children;
+  return React.createElement("div", undefined, "Another Hook " + vehicle[/* name */0], React.createElement("div", undefined, children));
+}
+
 var make = Hooks;
 
 var $$default = Hooks;
@@ -141,6 +147,8 @@ var makeWithRef = Hooks$makeWithRef;
 var polymorphicComponent = Hooks$polymorphicComponent;
 
 var functionReturningReactElement = Hooks$functionReturningReactElement;
+
+var aComponentWithChildren = Hooks$aComponentWithChildren;
 
 export {
   make ,
@@ -156,6 +164,7 @@ export {
   polymorphicComponent ,
   functionReturningReactElement ,
   RenderPropRequiresConversion ,
+  aComponentWithChildren ,
   
 }
 /* testForwardRef Not a pure module */

--- a/examples/flow-react-example/src/Hooks.gen.js
+++ b/examples/flow-react-example/src/Hooks.gen.js
@@ -172,3 +172,13 @@ export const RenderPropRequiresConversion_make: typeof(RenderPropRequiresConvers
     }});
   return result
 };
+
+// Type annotated function components are not checked by Flow, but typeof() works.
+const aComponentWithChildren$$forTypeof = function (_: {| +children: React$Node, +vehicle: vehicle |}) : React$Node { return null };
+
+export type aComponentWithChildren_Props = {| +children: React$Node, +vehicle: vehicle |};
+
+export const aComponentWithChildren: typeof(aComponentWithChildren$$forTypeof) = function Hooks_aComponentWithChildren(Arg1: $any) {
+  const result = HooksBS.aComponentWithChildren({children:Arg1.children, vehicle:[Arg1.vehicle.name]});
+  return result
+};

--- a/examples/flow-react-example/src/Hooks.re
+++ b/examples/flow-react-example/src/Hooks.re
@@ -138,3 +138,12 @@ module RenderPropRequiresConversion = {
     renderVehicle({"vehicle": car, "number": 42});
   };
 };
+
+[@genType]
+[@react.component]
+let aComponentWithChildren = (~vehicle, ~children) => {
+  <div>
+    {React.string("Another Hook " ++ vehicle.name)}
+    <div> children </div>
+  </div>;
+};

--- a/examples/typescript-react-example/src/Hooks.bs.js
+++ b/examples/typescript-react-example/src/Hooks.bs.js
@@ -128,6 +128,12 @@ function Hooks$RenderPropRequiresConversion(Props) {
 
 var RenderPropRequiresConversion = /* module */[/* make */Hooks$RenderPropRequiresConversion];
 
+function Hooks$aComponentWithChildren(Props) {
+  var vehicle = Props.vehicle;
+  var children = Props.children;
+  return React.createElement("div", undefined, "Another Hook " + vehicle[/* name */0], React.createElement("div", undefined, children));
+}
+
 var make = Hooks;
 
 var $$default = Hooks;
@@ -141,6 +147,8 @@ var makeWithRef = Hooks$makeWithRef;
 var polymorphicComponent = Hooks$polymorphicComponent;
 
 var functionReturningReactElement = Hooks$functionReturningReactElement;
+
+var aComponentWithChildren = Hooks$aComponentWithChildren;
 
 export {
   make ,
@@ -156,6 +164,7 @@ export {
   polymorphicComponent ,
   functionReturningReactElement ,
   RenderPropRequiresConversion ,
+  aComponentWithChildren ,
   
 }
 /* testForwardRef Not a pure module */

--- a/examples/typescript-react-example/src/Hooks.gen.tsx
+++ b/examples/typescript-react-example/src/Hooks.gen.tsx
@@ -147,3 +147,11 @@ export const RenderPropRequiresConversion_make: React.ComponentType<{ readonly r
     }});
   return result
 };
+
+// tslint:disable-next-line:interface-over-type-literal
+export type aComponentWithChildren_Props = { readonly children: React.ReactChild; readonly vehicle: vehicle };
+
+export const aComponentWithChildren: React.ComponentType<{ readonly children: React.ReactChild; readonly vehicle: vehicle }> = function Hooks_aComponentWithChildren(Arg1: any) {
+  const result = HooksBS.aComponentWithChildren({children:Arg1.children, vehicle:[Arg1.vehicle.name]});
+  return result
+};

--- a/examples/typescript-react-example/src/Hooks.re
+++ b/examples/typescript-react-example/src/Hooks.re
@@ -138,3 +138,12 @@ module RenderPropRequiresConversion = {
     renderVehicle({"vehicle": car, "number": 42});
   };
 };
+
+[@genType]
+[@react.component]
+let aComponentWithChildren = (~vehicle, ~children) => {
+  <div>
+    {React.string("Another Hook " ++ vehicle.name)}
+    <div> children </div>
+  </div>;
+};

--- a/src/EmitJs.re
+++ b/src/EmitJs.re
@@ -692,9 +692,22 @@ let rec emitCodeItem =
     let (type_, hookType) =
       switch (type_) {
       | Function(
-          {argTypes: [Object(_) as propsType], retType, typeVars} as function_,
+          {argTypes: [Object(closedFlags, fields)], retType, typeVars} as function_,
         )
           when retType |> EmitType.isTypeReactElement(~config) =>
+        let propsType = {
+          let fields =
+            fields
+            |> List.map((field: field) =>
+                 field.name == "children"
+                 && field.type_
+                 |> EmitType.isTypeReactElement(~config) ?
+                   {...field, type_: EmitType.typeReactChild(~config)} :
+                   field
+               );
+          Object(closedFlags, fields);
+        };
+        let function_ = {...function_, argTypes: [propsType]};
         let chopSuffix = suffix =>
           resolvedName == suffix ?
             "" :

--- a/src/EmitType.re
+++ b/src/EmitType.re
@@ -70,8 +70,14 @@ let typeReactElementFlow = ident(~builtin=true, "React$Node");
 
 let typeReactElementTypeScript = ident(~builtin=true, "JSX.Element");
 
+let typeReactChildTypeScript = ident(~builtin=true, "React.ReactChild");
+
 let typeReactElement = (~config) =>
   config.language == Flow ? typeReactElementFlow : typeReactElementTypeScript;
+
+let typeReactChild = (~config) =>
+  config.language == Flow ? typeReactElementFlow : typeReactChildTypeScript;
+
 
 let isTypeReactElement = (~config, type_) =>
   type_ === typeReactElement(~config);

--- a/src/EmitType.rei
+++ b/src/EmitType.rei
@@ -145,6 +145,8 @@ let outputFileSuffix: (~config: config) => string;
 
 let shimExtension: (~config: config) => string;
 
+let typeReactChild: (~config: config) => type_;
+
 let typeReactComponent: (~config: config, ~propsType: type_) => type_;
 
 let typeReactContext: (~config: config, ~type_: type_) => type_;


### PR DESCRIPTION
…act.ReactChild`.

Fixes https://github.com/cristianoc/genType/issues/239.