### PR TITLE
Prepare for records represented as objects.

### DIFF
--- a/src/Config_.re
+++ b/src/Config_.re
@@ -37,6 +37,7 @@ type config = {
   namespace: option(string),
   propTypes: bool,
   reasonReactPath: string,
+  recordsAsObjects: bool,
   fileHeader: option(string),
 };
 
@@ -60,6 +61,7 @@ let default = {
   namespace: None,
   propTypes: false,
   reasonReactPath: "reason-react/src/ReasonReact.js",
+  recordsAsObjects: false,
   fileHeader: None,
 };
 
@@ -279,6 +281,11 @@ let readConfig = (~bsVersion, ~getConfigFile, ~getBsConfigFile, ~namespace) => {
       | _ => v1 > 6
       };
     };
+    let recordsAsObjects = {
+      switch (v1) {
+      | _ => false /* TODO: insert appropriate version */
+      };
+    };
     if (Debug.config^) {
       logItem(
         "Config language:%s module:%s importPath:%s shims:%d entries bsVersion:%d.%d.%d\n",
@@ -312,6 +319,7 @@ let readConfig = (~bsVersion, ~getConfigFile, ~getBsConfigFile, ~namespace) => {
       namespace: None,
       propTypes,
       reasonReactPath,
+      recordsAsObjects,
       fileHeader,
     };
   };

--- a/src/Config_.re
+++ b/src/Config_.re
@@ -283,7 +283,9 @@ let readConfig = (~bsVersion, ~getConfigFile, ~getBsConfigFile, ~namespace) => {
     };
     let recordsAsObjects = {
       switch (v1) {
-      | _ => false /* TODO: insert appropriate version */
+      | 5 => bsVersion >= (5, 3, 0)
+      | 6 => bsVersion >= (6, 3, 0)
+      | _ => v1 > 6
       };
     };
     if (Debug.config^) {

--- a/src/TranslateTypeDeclarations.re
+++ b/src/TranslateTypeDeclarations.re
@@ -115,7 +115,9 @@ let traslateDeclarationKind =
              };
            {mutable_, name, optional, type_: type1};
          });
-    {TranslateTypeExprFromTypes.dependencies, type_: Record(fields)};
+    let type_ =
+      config.recordsAsObjects ? Object(Closed, fields) : Record(fields);
+    {TranslateTypeExprFromTypes.dependencies, type_};
   };
 
   switch (declarationKind, importStringOpt) {

--- a/src/TranslateTypeDeclarations.re
+++ b/src/TranslateTypeDeclarations.re
@@ -52,8 +52,8 @@ let traslateDeclarationKind =
     typeAttributes |> Annotation.getAttributeImportRenaming;
 
   let returnTypeDeclaration = (typeDeclaration: CodeItem.typeDeclaration) =>
-    opaque == Some(true) ?
-      [{...typeDeclaration, importTypes: []}] : [typeDeclaration];
+    opaque == Some(true)
+      ? [{...typeDeclaration, importTypes: []}] : [typeDeclaration];
 
   let handleGeneralDeclaration =
       (translation: TranslateTypeExprFromTypes.translation) => {


### PR DESCRIPTION
Still need to activate based on version, once the version number where the corresponding bucklescript changes ship is known:  https://github.com/BuckleScript/bucklescript/pull/3785.

Check conversion of:
- Variants with inline records.
- Extensible variants with inline records.
- Exceptions with inline records.
For each case, boxed/unboxed and arrays/objects should match.
