### PR TITLE
Make React.Ref more permissive: `{contents: null | T}`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,6 @@
 # master
 - Make React.Ref more permissive: `{contents: null | T}`.
+- Make `ReactDOMRe.domRef` map to `React.Ref`.
 
 # 2.41.0
 - Fix missing import React in untyped back-end.

--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,9 @@
 - Make React.Ref more permissive: `{contents: null | T}`.
 - Make `ReactDOMRe.domRef` map to `React.Ref`.
 
+# 3.0.0
+- This release is equivalent in functionality to `v2.41.0`, but targets bucklescript versions `6.2.x` (i.e. based on OCaml `4.6).
+
 # 2.41.0
 - Fix missing import React in untyped back-end.
 - Fix version detection for bucklescript 6.2.x (inner modules).

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,6 @@
+# master
+- Make React.Ref more permissive: `{contents: null | T}`.
+
 # 2.41.0
 - Fix missing import React in untyped back-end.
 - Fix version detection for bucklescript 6.2.x (inner modules).

--- a/examples/flow-react-example/src/Hooks.gen.js
+++ b/examples/flow-react-example/src/Hooks.gen.js
@@ -28,6 +28,8 @@ export type testReactContext = React$Context<number>;
 
 export type testReactRef = {| current: (null | number) |};
 
+export type testDomRef = React$Ref<mixed>;
+
 // Type annotated function components are not checked by Flow, but typeof() works.
 const $$default$$forTypeof = function (_: {| +vehicle: vehicle |}) : React$Node { return null };
 

--- a/examples/flow-react-example/src/Hooks.gen.js
+++ b/examples/flow-react-example/src/Hooks.gen.js
@@ -26,7 +26,7 @@ export type callback<input,output> = (input) => output;
 
 export type testReactContext = React$Context<number>;
 
-export type testReactRef = {| +current: (null | number) |};
+export type testReactRef = {| current: (null | number) |};
 
 // Type annotated function components are not checked by Flow, but typeof() works.
 const $$default$$forTypeof = function (_: {| +vehicle: vehicle |}) : React$Node { return null };

--- a/examples/flow-react-example/src/Hooks.gen.js
+++ b/examples/flow-react-example/src/Hooks.gen.js
@@ -26,7 +26,7 @@ export type callback<input,output> = (input) => output;
 
 export type testReactContext = React$Context<number>;
 
-export type testReactRef = React$Ref<number>;
+export type testReactRef = {| +current: (null | number) |};
 
 // Type annotated function components are not checked by Flow, but typeof() works.
 const $$default$$forTypeof = function (_: {| +vehicle: vehicle |}) : React$Node { return null };

--- a/examples/flow-react-example/src/Hooks.re
+++ b/examples/flow-react-example/src/Hooks.re
@@ -123,6 +123,9 @@ type testReactContext = React.Context.t(int);
 type testReactRef = React.Ref.t(int);
 
 [@genType]
+type testDomRef = ReactDOMRe.domRef;
+
+[@genType]
 [@react.component]
 let polymorphicComponent = (~p as (x, _)) => React.string(x.name);
 

--- a/examples/typescript-react-example/src/Hooks.gen.tsx
+++ b/examples/typescript-react-example/src/Hooks.gen.tsx
@@ -26,7 +26,7 @@ export type callback<input,output> = (_1:input) => output;
 export type testReactContext = React.Context<number>;
 
 // tslint:disable-next-line:interface-over-type-literal
-export type testReactRef = React.Ref<number>;
+export type testReactRef = { readonly current: (null | number) };
 
 // tslint:disable-next-line:interface-over-type-literal
 export type Props = { readonly vehicle: vehicle };

--- a/examples/typescript-react-example/src/Hooks.gen.tsx
+++ b/examples/typescript-react-example/src/Hooks.gen.tsx
@@ -29,6 +29,9 @@ export type testReactContext = React.Context<number>;
 export type testReactRef = { current: (null | number) };
 
 // tslint:disable-next-line:interface-over-type-literal
+export type testDomRef = React.Ref<unknown>;
+
+// tslint:disable-next-line:interface-over-type-literal
 export type Props = { readonly vehicle: vehicle };
 
 export const $$default: React.ComponentType<{ readonly vehicle: vehicle }> = function Hooks(Arg1: any) {

--- a/examples/typescript-react-example/src/Hooks.gen.tsx
+++ b/examples/typescript-react-example/src/Hooks.gen.tsx
@@ -26,7 +26,7 @@ export type callback<input,output> = (_1:input) => output;
 export type testReactContext = React.Context<number>;
 
 // tslint:disable-next-line:interface-over-type-literal
-export type testReactRef = { readonly current: (null | number) };
+export type testReactRef = { current: (null | number) };
 
 // tslint:disable-next-line:interface-over-type-literal
 export type Props = { readonly vehicle: vehicle };

--- a/examples/typescript-react-example/src/Hooks.re
+++ b/examples/typescript-react-example/src/Hooks.re
@@ -123,6 +123,9 @@ type testReactContext = React.Context.t(int);
 type testReactRef = React.Ref.t(int);
 
 [@genType]
+type testDomRef = ReactDOMRe.domRef;
+
+[@genType]
 [@react.component]
 let polymorphicComponent = (~p as (x, _)) => React.string(x.name);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gentype",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gentype",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "private": true,
   "description": "Use Reason values from Javascript: vanilla, or TypeScript/FlowType-annotated",
   "license": "MIT",

--- a/src/EmitType.re
+++ b/src/EmitType.re
@@ -81,6 +81,10 @@ let typeReactChild = (~config) =>
 let isTypeReactElement = (~config, type_) =>
   type_ === typeReactElement(~config);
 
+let typeReactDOMReDomRef = (~config) =>
+  (config.language == Flow ? "React$Ref" : "React.Ref")
+  |> ident(~builtin=true, ~typeArgs=[mixedOrUnknown(~config)]);
+
 let typeReactRef = (~config, ~type_) =>
   Object(
     Closed,

--- a/src/EmitType.re
+++ b/src/EmitType.re
@@ -82,8 +82,17 @@ let isTypeReactElement = (~config, type_) =>
   type_ === typeReactElement(~config);
 
 let typeReactRef = (~config, ~type_) =>
-  (config.language == Flow ? "React$Ref" : "React.Ref")
-  |> ident(~builtin=true, ~typeArgs=[type_]);
+  Object(
+    Closed,
+    [
+      {
+        mutable_: Immutable,
+        name: "current",
+        optional: Mandatory,
+        type_: Null(type_),
+      },
+    ],
+  );
 
 let componentExportName = (~config, ~fileName, ~moduleName) =>
   switch (config.language) {

--- a/src/EmitType.re
+++ b/src/EmitType.re
@@ -86,7 +86,7 @@ let typeReactRef = (~config, ~type_) =>
     Closed,
     [
       {
-        mutable_: Immutable,
+        mutable_: Mutable,
         name: "current",
         optional: Mandatory,
         type_: Null(type_),

--- a/src/EmitType.rei
+++ b/src/EmitType.rei
@@ -151,6 +151,8 @@ let typeReactComponent: (~config: config, ~propsType: type_) => type_;
 
 let typeReactContext: (~config: config, ~type_: type_) => type_;
 
+let typeReactDOMReDomRef: (~config: config) => type_;
+
 let typeReactElement: (~config: config) => type_;
 
 let typeReactRef: (~config: config, ~type_: type_) => type_;

--- a/src/TranslateTypeExprFromTypes.re
+++ b/src/TranslateTypeExprFromTypes.re
@@ -246,6 +246,11 @@ let translateConstr =
       type_: EmitType.typeReactRef(~config, ~type_=paramTranslation.type_),
     }
 
+  | (Pdot(Pident({name: "ReactDOMRe", _}), "domRef", _), []) => {
+      dependencies: [],
+      type_: EmitType.typeReactDOMReDomRef(~config),
+    }
+
   | (
       Pdot(
         Pdot(Pident({name: "ReactDOMRe", _}), "Ref", _),

--- a/src/Version.re
+++ b/src/Version.re
@@ -1,4 +1,4 @@
 
 /* CREATED BY genType/scripts/bump_version_module.js */
 /* DO NOT MODIFY BY HAND, WILL BE AUTOMATICALLY UPDATED BY npm version */
-let version = "3.0.0";
+let version = "3.1.0";


### PR DESCRIPTION
Fixes https://github.com/cristianoc/genType/issues/271