### PR TITLE
Find source dirs from bsconfig.json.

### DIFF
--- a/src/Config_.re
+++ b/src/Config_.re
@@ -41,6 +41,7 @@ type config = {
   reasonReactPath: string,
   recordsAsObjects: bool,
   shimsMap: ModuleNameMap.t(ModuleName.t),
+  sources: option(Ext_json_types.t),
   useBsDependencies: bool,
 };
 
@@ -67,6 +68,7 @@ let default = {
   reasonReactPath: "reason-react/src/ReasonReact.js",
   recordsAsObjects: false,
   shimsMap: ModuleNameMap.empty,
+  sources: None,
   useBsDependencies: false,
 };
 
@@ -338,6 +340,7 @@ let readConfig = (~bsVersion, ~getConfigFile, ~getBsConfigFile, ~namespace) => {
       reasonReactPath,
       recordsAsObjects,
       shimsMap,
+      sources: None,
       useBsDependencies,
     };
   };
@@ -369,6 +372,12 @@ let readConfig = (~bsVersion, ~getConfigFile, ~getBsConfigFile, ~namespace) => {
           {...config, bsDependencies: strings^};
         | _ => config
         };
+      let config = {
+        switch (map |> String_map.find_opt("sources")) {
+        | Some(sourceItem) => {...config, sources: Some(sourceItem)}
+        | _ => config
+        };
+      };
       config;
     | _ => default
     };

--- a/src/DeadCode.re
+++ b/src/DeadCode.re
@@ -75,7 +75,7 @@ let runAnalysis = () => {
     GenTypeCommon.projectRoot^ +++ "lib" +++ "bs";
   };
 
-  let sourceDirs = ModuleResolver.readSourceDirs();
+  let sourceDirs = ModuleResolver.readSourceDirs(~configSources=None);
   sourceDirs.dirs
   |> List.iter(sourceDir =>
        if (sourceDir |> whitelistSourceDir) {

--- a/src/GenType.re
+++ b/src/GenType.re
@@ -91,7 +91,8 @@ let cli = () => {
 
     | Clean =>
       let config = Paths.readConfig(~bsVersion, ~namespace=None);
-      let sourceDirs = ModuleResolver.readSourceDirs();
+      let sourceDirs =
+        ModuleResolver.readSourceDirs(~configSources=config.sources);
       if (Debug.basic^) {
         logItem("Clean %d dirs\n", sourceDirs.dirs |> List.length);
       };

--- a/src/ModuleResolver.re
+++ b/src/ModuleResolver.re
@@ -29,7 +29,7 @@ let readSourceDirs = () => {
   let dirs = ref([]);
   let pkgs = Hashtbl.create(1);
 
-  let getDirsPkgs = json => {
+  let readDirs = json => {
     switch (json) {
     | Ext_json_types.Obj({map}) =>
       switch (map |> String_map.find_opt("dirs")) {
@@ -43,7 +43,14 @@ let readSourceDirs = () => {
            );
         ();
       | _ => ()
-      };
+      }
+    | _ => ()
+    };
+  };
+
+  let readPkgs = json => {
+    switch (json) {
+    | Ext_json_types.Obj({map}) =>
       switch (map |> String_map.find_opt("pkgs")) {
       | Some(Arr({content})) =>
         content
@@ -58,13 +65,17 @@ let readSourceDirs = () => {
            );
         ();
       | _ => ()
-      };
+      }
     | _ => ()
     };
   };
 
   if (sourceDirs |> Sys.file_exists) {
-    try(sourceDirs |> Ext_json_parse.parse_json_from_file |> getDirsPkgs) {
+    try({
+      let json = sourceDirs |> Ext_json_parse.parse_json_from_file;
+      json |> readDirs;
+      json |> readPkgs;
+    }) {
     | _ => ()
     };
   } else {


### PR DESCRIPTION
When a subproject is built from a root project, `bsb` does not create `lib/bs/.sourcedirs.json`.
This OR work around this limitation by finding the potential source dirs from the sources spec given in `bsconfig.json`.

NOTE: This still does not cover the case of dependencies which themselves use dependencies. For that to work, one needs to read the `"pkgs"` section of `.sourcedirs.json` in the bsb root directory.
This will be fixed when https://github.com/BuckleScript/bucklescript/commit/95bde3e69db7fa63b07c5d810d2ddf4e2231270a makes into a bucklescript release.
