### PR TITLE
Fix record renaming conversion for bs 7.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,8 @@
 # master
 - Add support for building sub-projects from the root project.
   For more details, see: https://github.com/cristianoc/genType/pull/318.
+- With bucklescript 7.x.y, apply conversion when a record field requires conversion.
+
 
 # 3.4.2
 - Add support for scoped packages (e.g. `@demo/somelibrary`) in `bs-dependencies` when `"use-bs-dependencies": true` is specified in `gentypeconfig`. Note that dependent packages should be built first. If you rely on bucklescript to build them starting from the root package, it will not work (as the required `lib/bs/.sourcedirs.json` will be missing). This will be addressed in a future version of bucklescript.

--- a/examples/commonjs-react-example/package-lock.json
+++ b/examples/commonjs-react-example/package-lock.json
@@ -1493,9 +1493,9 @@
       }
     },
     "bs-platform": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-6.2.0.tgz",
-      "integrity": "sha512-UU/X6LvOLzDZ8QEDTzANvAhuztD9rqbATodWW1bUwAtgHKLT7KCXdhX/UmVwHU3j4+fAE4rExdVfXb7FqnsLdg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-6.2.1.tgz",
+      "integrity": "sha512-FmQ8kYV52A0Y302qh6o0/J9TO+kHzsjGQnsjrg/ONUYIY/jWzBnt9dCBO6EBnaEKfFJLqk5JrUDCxuihqtTcnw==",
       "dev": true
     },
     "buffer": {

--- a/examples/commonjs-react-example/package.json
+++ b/examples/commonjs-react-example/package.json
@@ -27,7 +27,7 @@
     "@babel/preset-flow": "^7.0.0-beta.54",
     "@babel/preset-react": "^7.0.0-beta.54",
     "babel-loader": "^8.0.0-beta.4",
-    "bs-platform": "^6.2.0",
+    "bs-platform": "6.2.1",
     "concurrently": "^3.5.0",
     "webpack": "^4.0.1",
     "webpack-cli": "^3.1.2"

--- a/examples/flow-react-example/package.json
+++ b/examples/flow-react-example/package.json
@@ -27,7 +27,7 @@
     "@babel/preset-flow": "^7.0.0-beta.54",
     "@babel/preset-react": "^7.0.0-beta.54",
     "babel-loader": "^8.0.0-beta.4",
-    "bs-platform": "^6.2.1",
+    "bs-platform": "6.2.1",
     "concurrently": "^3.5.0",
     "webpack": "^4.0.1",
     "webpack-cli": "^3.1.2"

--- a/examples/flow-react-example/src/Tuples.gen.js
+++ b/examples/flow-react-example/src/Tuples.gen.js
@@ -17,7 +17,7 @@ export type coord = [number, number, ?number];
 
 export type coord2 = [number, number, ?number];
 
-export type person = {| +name: string, +age: number |};
+export type person = {| +Name: string, +age: number |};
 
 export type couple = [person, person];
 
@@ -43,16 +43,16 @@ export const coord2d: <T1,T2,T3>(T1, T2) => [T1, T2, ?T3] = function <T1,T2,T3>(
 };
 
 export const getFirstName: (couple) => string = function (Arg1: $any) {
-  const result = TuplesBS.getFirstName([[Arg1[0].name, Arg1[0].age], [Arg1[1].name, Arg1[1].age]]);
+  const result = TuplesBS.getFirstName([[Arg1[0].Name, Arg1[0].age], [Arg1[1].Name, Arg1[1].age]]);
   return result
 };
 
 export const marry: (person, person) => couple = function (Arg1: $any, Arg2: $any) {
-  const result = Curry._2(TuplesBS.marry, [Arg1.name, Arg1.age], [Arg2.name, Arg2.age]);
-  return [{name:result[0][0], age:result[0][1]}, {name:result[1][0], age:result[1][1]}]
+  const result = Curry._2(TuplesBS.marry, [Arg1.Name, Arg1.age], [Arg2.Name, Arg2.age]);
+  return [{Name:result[0][0], age:result[0][1]}, {Name:result[1][0], age:result[1][1]}]
 };
 
 export const changeSecondAge: (couple) => couple = function (Arg1: $any) {
-  const result = TuplesBS.changeSecondAge([[Arg1[0].name, Arg1[0].age], [Arg1[1].name, Arg1[1].age]]);
-  return [{name:result[0][0], age:result[0][1]}, {name:result[1][0], age:result[1][1]}]
+  const result = TuplesBS.changeSecondAge([[Arg1[0].Name, Arg1[0].age], [Arg1[1].Name, Arg1[1].age]]);
+  return [{Name:result[0][0], age:result[0][1]}, {Name:result[1][0], age:result[1][1]}]
 };

--- a/examples/flow-react-example/src/Tuples.re
+++ b/examples/flow-react-example/src/Tuples.re
@@ -28,6 +28,7 @@ type coord2 = (int, int, Js.Nullable.t(int));
 
 [@genType]
 type person = {
+  [@genType.as "Name"]
   name: string,
   age: int,
 };

--- a/examples/flow-react-example/src/TypeExpansion.gen.js
+++ b/examples/flow-react-example/src/TypeExpansion.gen.js
@@ -26,6 +26,6 @@ export type A_user = {| +name: string |};
 export type b = A_user;
 
 export const testConversion: (topType) => topType = function (Arg1: $any) {
-  const result = TypeExpansionBS.testConversion([Arg1[0], {lowerType:[[Arg1[1].lowerType.person.name, Arg1[1].lowerType.person.age]]}]);
-  return [result[0], {lowerType:{person:{name:result[1].lowerType[0][0], age:result[1].lowerType[0][1]}}}]
+  const result = TypeExpansionBS.testConversion([Arg1[0], {lowerType:[[Arg1[1].lowerType.person.Name, Arg1[1].lowerType.person.age]]}]);
+  return [result[0], {lowerType:{person:{Name:result[1].lowerType[0][0], age:result[1].lowerType[0][1]}}}]
 };

--- a/examples/typescript-react-example/package.json
+++ b/examples/typescript-react-example/package.json
@@ -25,7 +25,7 @@
     "@types/node": "^10.5.5",
     "@types/react": "^16.4.7",
     "@types/react-dom": "^16.0.6",
-    "bs-platform": "^6.2.1",
+    "bs-platform": "6.2.1",
     "typescript": "^3.7.2"
   },
   "browserslist": [

--- a/examples/typescript-react-example/src/AutoAnnotate.re
+++ b/examples/typescript-react-example/src/AutoAnnotate.re
@@ -2,7 +2,7 @@ type variant =
   | R(int);
 
 [@genType]
-type record = {variant: variant};
+type record = {variant};
 
 type r2 = {r2: int};
 

--- a/examples/typescript-react-example/src/DeadCodeInterface.re
+++ b/examples/typescript-react-example/src/DeadCodeInterface.re
@@ -1,3 +1,1 @@
-module type T = {
-  let x : int;
-};
+module type T = {let x: int;};

--- a/examples/typescript-react-example/src/ReasonComponent.gen.tsx
+++ b/examples/typescript-react-example/src/ReasonComponent.gen.tsx
@@ -51,7 +51,7 @@ export type Props = {
 export const ReasonComponent: React.ComponentType<Props> = ReasonReact.wrapReasonForJs(
   ReasonComponentBS.component,
   (function _(jsProps: Props) {
-     return Curry._4(ReasonComponentBS.make, jsProps.message, [jsProps.person.name, jsProps.person.surname, jsProps.person.type, jsProps.person.polymorphicPayload], jsProps.intList, jsProps.children);
+     return Curry._4(ReasonComponentBS.make, jsProps.message, [jsProps.person.name, jsProps.person.surname, jsProps.person.type_, jsProps.person.polymorphicPayload], jsProps.intList, jsProps.children);
   }));
 
 export default ReasonComponent;

--- a/examples/typescript-react-example/src/ReasonComponent.gen.tsx
+++ b/examples/typescript-react-example/src/ReasonComponent.gen.tsx
@@ -51,7 +51,7 @@ export type Props = {
 export const ReasonComponent: React.ComponentType<Props> = ReasonReact.wrapReasonForJs(
   ReasonComponentBS.component,
   (function _(jsProps: Props) {
-     return Curry._4(ReasonComponentBS.make, jsProps.message, [jsProps.person.name, jsProps.person.surname, jsProps.person.type_, jsProps.person.polymorphicPayload], jsProps.intList, jsProps.children);
+     return Curry._4(ReasonComponentBS.make, jsProps.message, [jsProps.person.name, jsProps.person.surname, jsProps.person.type, jsProps.person.polymorphicPayload], jsProps.intList, jsProps.children);
   }));
 
 export default ReasonComponent;

--- a/examples/typescript-react-example/src/Records.bs.js
+++ b/examples/typescript-react-example/src/Records.bs.js
@@ -107,6 +107,22 @@ function computeArea4(o) {
                   })));
 }
 
+function testMyRec(x) {
+  return x[/* type_ */0];
+}
+
+function testMyRec2(x) {
+  return x;
+}
+
+function testMyObj(x) {
+  return x.type_;
+}
+
+function testMyObj2(x) {
+  return x;
+}
+
 var origin = /* record */[
   /* x */0,
   /* y */0,
@@ -136,6 +152,10 @@ export {
   someBusiness2 ,
   computeArea3 ,
   computeArea4 ,
+  testMyRec ,
+  testMyRec2 ,
+  testMyObj ,
+  testMyObj2 ,
   
 }
 /* No side effect */

--- a/examples/typescript-react-example/src/Records.gen.tsx
+++ b/examples/typescript-react-example/src/Records.gen.tsx
@@ -54,6 +54,12 @@ export type mix = {
   }
 };
 
+// tslint:disable-next-line:interface-over-type-literal
+export type myRec = { readonly type: string };
+
+// tslint:disable-next-line:interface-over-type-literal
+export type myObj = { readonly type_: string };
+
 export const origin: coord = {x:RecordsBS.origin[0], y:RecordsBS.origin[1], z:RecordsBS.origin[2]};
 
 export const computeArea: (_1:coord) => number = function (Arg1: any) {
@@ -115,3 +121,17 @@ export const computeArea4: (_1:{
   readonly y: number; 
   readonly z?: number
 }) => number = RecordsBS.computeArea4;
+
+export const testMyRec: (_1:myRec) => string = function (Arg1: any) {
+  const result = RecordsBS.testMyRec([Arg1.type_]);
+  return result
+};
+
+export const testMyRec2: (_1:myRec) => myRec = function (Arg1: any) {
+  const result = RecordsBS.testMyRec2([Arg1.type_]);
+  return {type:result[0]}
+};
+
+export const testMyObj: (_1:myObj) => string = RecordsBS.testMyObj;
+
+export const testMyObj2: (_1:myObj) => myObj = RecordsBS.testMyObj2;

--- a/examples/typescript-react-example/src/Records.gen.tsx
+++ b/examples/typescript-react-example/src/Records.gen.tsx
@@ -123,12 +123,12 @@ export const computeArea4: (_1:{
 }) => number = RecordsBS.computeArea4;
 
 export const testMyRec: (_1:myRec) => string = function (Arg1: any) {
-  const result = RecordsBS.testMyRec([Arg1.type_]);
+  const result = RecordsBS.testMyRec([Arg1.type]);
   return result
 };
 
 export const testMyRec2: (_1:myRec) => myRec = function (Arg1: any) {
-  const result = RecordsBS.testMyRec2([Arg1.type_]);
+  const result = RecordsBS.testMyRec2([Arg1.type]);
   return {type:result[0]}
 };
 

--- a/examples/typescript-react-example/src/Records.re
+++ b/examples/typescript-react-example/src/Records.re
@@ -135,3 +135,24 @@ type mix = {
       "surname": string,
     }),
 };
+
+[@genType]
+type myRec = {
+  [@genType.as "type"]
+  type_: string,
+};
+
+[@genType]
+type myObj = {. "type_": string};
+
+[@genType]
+let testMyRec = (x: myRec) => x.type_;
+
+[@genType]
+let testMyRec2 = (x: myRec) => x;
+
+[@genType]
+let testMyObj = (x: myObj) => x##type_;
+
+[@genType]
+let testMyObj2 = (x: myObj) => x;

--- a/examples/typescript-react-example/src/References.re
+++ b/examples/typescript-react-example/src/References.re
@@ -9,7 +9,6 @@ let access = r => r.contents + 1;
 [@genType]
 let update = r => r.contents = r.contents + 1;
 
-
 // Abstract version of references: works when conversion is required.
 
 module R: {

--- a/examples/untyped-react-example/package-lock.json
+++ b/examples/untyped-react-example/package-lock.json
@@ -1361,9 +1361,9 @@
       }
     },
     "bs-platform": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-6.2.0.tgz",
-      "integrity": "sha512-UU/X6LvOLzDZ8QEDTzANvAhuztD9rqbATodWW1bUwAtgHKLT7KCXdhX/UmVwHU3j4+fAE4rExdVfXb7FqnsLdg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-6.2.1.tgz",
+      "integrity": "sha512-FmQ8kYV52A0Y302qh6o0/J9TO+kHzsjGQnsjrg/ONUYIY/jWzBnt9dCBO6EBnaEKfFJLqk5JrUDCxuihqtTcnw==",
       "dev": true
     },
     "buffer": {

--- a/examples/untyped-react-example/package.json
+++ b/examples/untyped-react-example/package.json
@@ -25,7 +25,7 @@
     "@babel/preset-env": "^7.0.0-beta.54",
     "@babel/preset-react": "^7.0.0-beta.54",
     "babel-loader": "^8.0.0-beta.4",
-    "bs-platform": "^6.2.0",
+    "bs-platform": "6.2.1",
     "concurrently": "^3.5.0",
     "webpack": "^4.0.1",
     "webpack-cli": "^3.1.2"

--- a/src/Converter.re
+++ b/src/Converter.re
@@ -15,7 +15,12 @@ type t =
 and groupedArgConverter =
   | ArgConverter(t)
   | GroupConverter(list((string, optional, t)))
-and fieldsC = list((string, t))
+and fieldC = {
+  lblJS: string,
+  lblRE: string,
+  c: t,
+}
+and fieldsC = list(fieldC)
 and functionC = {
   argConverters: list(groupedArgConverter),
   componentName: option(string),
@@ -83,7 +88,11 @@ let rec toString = converter =>
     ++ dot
     ++ (
       fieldsC
-      |> List.map(((lbl, c)) => lbl ++ ":" ++ (c |> toString))
+      |> List.map(({lblJS, lblRE, c}) =>
+           (lblJS == lblRE ? lblJS : "(" ++ lblJS ++ "/" ++ lblRE ++ ")")
+           ++ ":"
+           ++ (c |> toString)
+         )
       |> String.concat(", ")
     )
     ++ "}";
@@ -93,7 +102,7 @@ let rec toString = converter =>
   | TupleC(innerTypesC) =>
     "[" ++ (innerTypesC |> List.map(toString) |> String.concat(", ")) ++ "]"
 
-  | VariantC({noPayloads, withPayload, _}) =>
+  | VariantC({noPayloads, withPayload}) =>
     "variant("
     ++ (
       (noPayloads |> List.map(case => case.labelJS |> labelJSToString))
@@ -172,11 +181,11 @@ let typeGetConverterNormalized =
       } else {
         let visited = visited |> StringSet.add(name);
         switch (name |> lookupId) {
-        | {annotation: GenTypeOpaque, _} => (IdentC, normalized_)
-        | {annotation: NoGenType, _} => (IdentC, normalized_)
-        | {typeVars, type_, _} =>
+        | {annotation: GenTypeOpaque} => (IdentC, normalized_)
+        | {annotation: NoGenType} => (IdentC, normalized_)
+        | {typeVars, type_} =>
           let pairs =
-            try (List.combine(typeVars, typeArgs)) {
+            try(List.combine(typeVars, typeArgs)) {
             | Invalid_argument(_) => []
             };
 
@@ -218,8 +227,12 @@ let typeGetConverterNormalized =
       (
         ObjectC(
           fieldsConverted
-          |> List.map((({name, optional, _}, (converter, _))) =>
-               (name, optional == Mandatory ? converter : OptionC(converter))
+          |> List.map((({nameJS, nameRE, optional}, (converter, _))) =>
+               {
+                 lblJS: nameJS,
+                 lblRE: nameRE,
+                 c: optional == Mandatory ? converter : OptionC(converter),
+               }
              ),
         ),
         Object(
@@ -248,8 +261,12 @@ let typeGetConverterNormalized =
       (
         RecordC(
           fieldsConverted
-          |> List.map((({name, optional}, (converter, _))) =>
-               (name, optional == Mandatory ? converter : OptionC(converter))
+          |> List.map((({nameJS, nameRE, optional}, (converter, _))) =>
+               {
+                 lblJS: nameJS,
+                 lblRE: nameRE,
+                 c: optional == Mandatory ? converter : OptionC(converter),
+               }
              ),
         ),
         Record(
@@ -330,8 +347,8 @@ let typeGetConverterNormalized =
       let converter =
         GroupConverter(
           fieldsConverted
-          |> List.map((({name, optional, _}, (converter, _))) =>
-               (name, optional, converter)
+          |> List.map((({nameJS, optional}, (converter, _))) =>
+               (nameJS, optional, converter)
              ),
         );
       (converter, tNormalized);
@@ -400,11 +417,14 @@ let rec converterIsIdentity = (~toJS, converter) =>
 
   | ObjectC(fieldsC) =>
     fieldsC
-    |> List.for_all(((_, c)) =>
-         switch (c) {
-         | OptionC(c1) => c1 |> converterIsIdentity(~toJS)
-         | _ => c |> converterIsIdentity(~toJS)
-         }
+    |> List.for_all(({lblJS, lblRE, c}) =>
+         lblJS == lblRE
+         && (
+           switch (c) {
+           | OptionC(c1) => c1 |> converterIsIdentity(~toJS)
+           | _ => c |> converterIsIdentity(~toJS)
+           }
+         )
        )
 
   | OptionC(c) =>
@@ -640,12 +660,12 @@ let rec apply =
       };
     let fieldValues =
       fieldsC
-      |> List.map(((label, fieldConverter)) =>
-           label
+      |> List.map(({lblJS, lblRE, c: fieldConverter}) =>
+           (toJS ? lblJS : lblRE)
            ++ ":"
            ++ (
              value
-             |> EmitText.fieldAccess(~label)
+             |> EmitText.fieldAccess(~label=toJS ? lblRE : lblJS)
              |> apply(
                   ~config,
                   ~converter=fieldConverter |> simplifyFieldConverted,
@@ -725,8 +745,8 @@ let rec apply =
     if (toJS) {
       let fieldValues =
         fieldsC
-        |> List.mapi((index, (lbl, fieldConverter)) =>
-             lbl
+        |> List.mapi((index, {lblJS, c: fieldConverter}) =>
+             lblJS
              ++ ":"
              ++ (
                value
@@ -747,9 +767,9 @@ let rec apply =
     } else {
       let fieldValues =
         fieldsC
-        |> List.map(((label, fieldConverter)) =>
+        |> List.map(({lblRE, c: fieldConverter}) =>
              value
-             |> EmitText.fieldAccess(~label)
+             |> EmitText.fieldAccess(~label=lblRE)
              |> apply(
                   ~config,
                   ~converter=fieldConverter |> simplifyFieldConverted,
@@ -782,7 +802,7 @@ let rec apply =
     )
     ++ "]"
 
-  | VariantC({noPayloads: [case], withPayload: [], polymorphic, _}) =>
+  | VariantC({noPayloads: [case], withPayload: [], polymorphic}) =>
     toJS
       ? case.labelJS |> labelJSToString
       : case.label |> Runtime.emitVariantLabel(~polymorphic)

--- a/src/Converter.re
+++ b/src/Converter.re
@@ -767,9 +767,9 @@ let rec apply =
     } else {
       let fieldValues =
         fieldsC
-        |> List.map(({lblRE, c: fieldConverter}) =>
+        |> List.map(({lblJS, c: fieldConverter}) =>
              value
-             |> EmitText.fieldAccess(~label=lblRE)
+             |> EmitText.fieldAccess(~label=lblJS)
              |> apply(
                   ~config,
                   ~converter=fieldConverter |> simplifyFieldConverted,

--- a/src/EmitJs.re
+++ b/src/EmitJs.re
@@ -328,7 +328,7 @@ let rec emitCodeItem =
       (
         "function "
         ++ EmitText.parens(
-             (propsFields |> List.map(({name, _}: field) => name))
+             (propsFields |> List.map(({nameJS, _}: field) => nameJS))
              @ ["children"]
              |> List.map(EmitType.ofTypeAny(~config)),
            )
@@ -338,7 +338,7 @@ let rec emitCodeItem =
              "{"
              ++ (
                propsFields
-               |> List.map(({name: propName, optional, type_: propTyp, _}) =>
+               |> List.map(({nameJS: propName, optional, type_: propTyp, _}) =>
                     propName
                     ++ ": "
                     ++ (
@@ -704,7 +704,7 @@ let rec emitCodeItem =
           let fields =
             fields
             |> List.map((field: field) =>
-                 field.name == "children"
+                 field.nameJS == "children"
                  && field.type_
                  |> EmitType.isTypeReactElement(~config)
                    ? {...field, type_: EmitType.typeReactChild(~config)}

--- a/src/EmitType.re
+++ b/src/EmitType.re
@@ -91,7 +91,8 @@ let typeReactRef = (~config, ~type_) =>
     [
       {
         mutable_: Mutable,
-        name: "current",
+        nameJS: "current",
+        nameRE: "current",
         optional: Mandatory,
         type_: Null(type_),
       },
@@ -265,7 +266,8 @@ let rec renderType =
       noPayloads |> List.map(case => case.labelJS |> labelJSToString);
     let field = (~name, value) => {
       mutable_: Mutable,
-      name,
+      nameJS: name,
+      nameRE: name,
       optional: Mandatory,
       type_: TypeVar(value),
     };
@@ -307,7 +309,7 @@ and renderField =
       ~indent,
       ~typeNameIsInterface,
       ~inFunType,
-      {mutable_, name: lbl, optional, type_},
+      {mutable_, nameJS: lbl, optional, type_},
     ) => {
   let optMarker = optional === Optional ? "?" : "";
   let mutMarker =
@@ -681,7 +683,7 @@ let emitPropTypes = (~config, ~emitters, ~indent, ~name, fields) => {
       ++ Indent.break(~indent=indent1)
       ++ (
         fields
-        |> List.filter(({name}: field) => name != "children")
+        |> List.filter(({nameJS}: field) => nameJS != "children")
         |> List.map(emitField(~indent=indent1))
         |> String.concat("," ++ Indent.break(~indent=indent1))
       )
@@ -697,8 +699,8 @@ let emitPropTypes = (~config, ~emitters, ~indent, ~name, fields) => {
     | TypeVar(_)
     | Variant(_) => "any" |> prefix
     }
-  and emitField = (~indent, {name, optional, type_}: field) =>
-    name
+  and emitField = (~indent, {nameJS, optional, type_}: field) =>
+    nameJS
     ++ " : "
     ++ (type_ |> emitType(~indent))
     ++ (optional == Mandatory ? ".isRequired" : "");
@@ -711,7 +713,7 @@ let emitPropTypes = (~config, ~emitters, ~indent, ~name, fields) => {
   ++ Indent.break(~indent=indent1)
   ++ (
     fields
-    |> List.filter(({name}: field) => name != "children")
+    |> List.filter(({nameJS}: field) => nameJS != "children")
     |> List.map(emitField(~indent=indent1))
     |> String.concat("," ++ Indent.break(~indent=indent1))
   )

--- a/src/ExportModule.re
+++ b/src/ExportModule.re
@@ -31,7 +31,8 @@ and exportModuleItemToFields: exportModuleItem => list((field, field)) =
           exportModuleValue |> exportModuleValueToType;
         let fieldForType = {
           mutable_: Mutable,
-          name: fieldName,
+          nameJS: fieldName,
+          nameRE: fieldName,
           optional: Mandatory,
           type_: typeForType,
         };

--- a/src/GenTypeCommon.re
+++ b/src/GenTypeCommon.re
@@ -65,7 +65,8 @@ and builtin =
 and fields = list(field)
 and field = {
   mutable_,
-  name: string,
+  nameJS: string,
+  nameRE: string,
   optional,
   type_,
 }

--- a/src/NamedArgs.re
+++ b/src/NamedArgs.re
@@ -20,7 +20,13 @@ let rec groupReversed = (~revCurGroup, ~revResult, labeledTypes) =>
   | (_, [(OptLabel(name), type_), ...tl]) =>
     groupReversed(
       ~revCurGroup=[
-        {mutable_: Immutable, name, optional: Optional, type_},
+        {
+          mutable_: Immutable,
+          nameJS: name,
+          nameRE: name,
+          optional: Optional,
+          type_,
+        },
         ...revCurGroup,
       ],
       ~revResult,
@@ -29,7 +35,13 @@ let rec groupReversed = (~revCurGroup, ~revResult, labeledTypes) =>
   | (_, [(Label(name), type_), ...tl]) =>
     groupReversed(
       ~revCurGroup=[
-        {mutable_: Immutable, name, optional: Mandatory, type_},
+        {
+          mutable_: Immutable,
+          nameJS: name,
+          nameRE: name,
+          optional: Mandatory,
+          type_,
+        },
         ...revCurGroup,
       ],
       ~revResult,

--- a/src/TranslateStructure.re
+++ b/src/TranslateStructure.re
@@ -24,7 +24,7 @@ and addAnnotationsToFields =
     | Some(StringPayload(s)) =>
       let (nextFields1, types1) =
         addAnnotationsToFields(c_rhs, nextFields, types);
-      ([{...field, name: s}, ...nextFields1], types1);
+      ([{...field, nameJS: s}, ...nextFields1], types1);
     | _ =>
       let (nextFields1, types1) =
         addAnnotationsToFields(c_rhs, nextFields, types);

--- a/src/TranslateTypeExprFromTypes.re
+++ b/src/TranslateTypeExprFromTypes.re
@@ -412,7 +412,7 @@ let translateConstr =
              | _ => (Mandatory, t)
              };
            let name = name |> Runtime.mangleObjectField;
-           {mutable_, name, optional, type_};
+           {mutable_, nameJS: name, nameRE: name, optional, type_};
          });
     let type_ = Object(closedFlag, fields);
     {dependencies, type_};
@@ -792,7 +792,8 @@ and signatureToModuleRuntimeRepresentation =
                 );
            let field = {
              mutable_: Immutable,
-             name: id |> Ident.name,
+             nameJS: id |> Ident.name,
+             nameRE: id |> Ident.name,
              optional: Mandatory,
              type_,
            };
@@ -819,7 +820,8 @@ and signatureToModuleRuntimeRepresentation =
              };
            let field = {
              mutable_: Immutable,
-             name: id |> Ident.name,
+             nameJS: id |> Ident.name,
+             nameRE: id |> Ident.name,
              optional: Mandatory,
              type_,
            };

--- a/src/Translation.re
+++ b/src/Translation.re
@@ -221,7 +221,8 @@ let translateComponent =
         GroupOfLabeledArgs([
           {
             mutable_: Immutable,
-            name: "children",
+            nameJS: "children",
+            nameRE: "children",
             optional: Optional,
             type_: mixedOrUnknown(~config),
           },
@@ -235,7 +236,8 @@ let translateComponent =
             @ [
               {
                 mutable_: Immutable,
-                name: "children",
+                nameJS: "children",
+                nameRE: "children",
                 optional: Optional,
                 type_: childrenType,
               },


### PR DESCRIPTION
With bucklescript 7.x.y, apply conversion when a record field requires conversion.