### PR TITLE
Dependent projects: turn on by default, and document the feature.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,21 +1,16 @@
 # master
 
-# 3.4.3
-- Add support for building sub-projects from the root project.
-  For more details, see: https://github.com/cristianoc/genType/pull/318.
-- With bucklescript 7.x.y, apply conversion when a record field requires renaming.
-
-# 3.4.2
-- Add support for scoped packages (e.g. `@demo/somelibrary`) in `bs-dependencies` when `"use-bs-dependencies": true` is specified in `gentypeconfig`. Note that dependent packages should be built first. If you rely on bucklescript to build them starting from the root package, it will not work (as the required `lib/bs/.sourcedirs.json` will be missing). This will be addressed in a future version of bucklescript.
-
-# 3.4.1
-- Read type information from libraries when `"use-bs-dependencies": true` is specified in `gentypeconfig`.
-  This is an experimental feature under development.
-  For example, if the dependencies are `"bs-dependencies": ["somelibrary"]` and `somelibrary` contains `Common.re`, this looks up types in the library:
+# 3.4.4
+- Add support for bucklescript dependencies, specified in `bs-dependencies`.
+  For example, if the dependencies are `"bs-dependencies": ["somelibrary"]` and `somelibrary` contains `Common.re`, this looks up the types of `foo` in the library:
   ```reason
   [@genType]
   let z = Common.foo;
   ```
+  Scoped packages of the form e.g. `@demo/somelibrary` are also supported.
+  Note: the library must have been published with the `.gen.ts` files created by genType.
+  
+- With bucklescript 7.x.y, apply conversion when a record field requires renaming.
 
 # 3.3.0
 - Fix issue with `[@genType.import "."]` and `[@genType.import ".."]` where the conversion function would be called `.`, which is not a valid name. See https://github.com/cristianoc/genType/issues/296.

--- a/README.md
+++ b/README.md
@@ -294,7 +294,20 @@ let functionWithGenTypeAs =
   (~date: float) => [@genType.as "type"] (~type_: string) => ...
 ```
 
-**NOTE** For technical reasons, it is not possible to use `g@enType.as` on the first argument of a function (restriction lifted on OCaml 4.0.6).
+**NOTE** For technical reasons, it is not possible to use `@genType.as` on the first argument of a function (restriction lifted on OCaml 4.0.6).
+
+### Dependent projects/libraries
+Bucklescript dependencies are specified in `bs-dependencies`.
+For example, if the dependencies are `"bs-dependencies": ["somelibrary"]` and `somelibrary` contains `Common.re`, this looks up the types of `foo` in the library:
+
+```reason
+  [@genType]
+  let z = Common.foo;
+```
+
+Scoped packages of the form e.g. `@demo/somelibrary` are also supported.
+
+**NOTE** The library must have been published with the `.gen.ts` files created by genType.
 
 
 ## Configuration

--- a/examples/typescript-react-example/bsconfig.json
+++ b/examples/typescript-react-example/bsconfig.json
@@ -14,7 +14,6 @@
       "all": false
     },
     "exportInterfaces": false,
-    "use-bs-dependencies": true,
     "path": "../GenType.exe"
   },
   "name": "sample-typescript-app",

--- a/examples/typescript-react-example/use-some-library/bsconfig.json
+++ b/examples/typescript-react-example/use-some-library/bsconfig.json
@@ -19,7 +19,6 @@
   "gentypeconfig": {
     "language": "typescript",
     "module": "es6",
-    "use-bs-dependencies": true,
     "path": "../../GenType.exe"
   }
 }

--- a/src/Config_.re
+++ b/src/Config_.re
@@ -42,7 +42,6 @@ type config = {
   recordsAsObjects: bool,
   shimsMap: ModuleNameMap.t(ModuleName.t),
   sources: option(Ext_json_types.t),
-  useBsDependencies: bool,
 };
 
 let default = {
@@ -69,7 +68,6 @@ let default = {
   recordsAsObjects: false,
   shimsMap: ModuleNameMap.empty,
   sources: None,
-  useBsDependencies: false,
 };
 
 let bsPlatformLib = (~config) =>
@@ -204,7 +202,6 @@ let readConfig = (~bsVersion, ~getConfigFile, ~getBsConfigFile, ~namespace) => {
     let generatedFileExtensionStringOption =
       json |> getStringOption("generatedFileExtension");
     let propTypesBool = json |> getBool("propTypes");
-    let useBsDependenciesBool = json |> getBool("use-bs-dependencies");
     let shimsMap =
       json
       |> getShims
@@ -259,11 +256,6 @@ let readConfig = (~bsVersion, ~getConfigFile, ~getBsConfigFile, ~namespace) => {
     let propTypes =
       switch (propTypesBool) {
       | None => default.propTypes
-      | Some(b) => b
-      };
-    let useBsDependencies =
-      switch (useBsDependenciesBool) {
-      | None => default.useBsDependencies
       | Some(b) => b
       };
     let fileHeader = fileHeader;
@@ -341,7 +333,6 @@ let readConfig = (~bsVersion, ~getConfigFile, ~getBsConfigFile, ~namespace) => {
       recordsAsObjects,
       shimsMap,
       sources: None,
-      useBsDependencies,
     };
   };
 

--- a/src/ModuleResolver.re
+++ b/src/ModuleResolver.re
@@ -68,7 +68,8 @@ let readDirsFromConfig = (~configSources) => {
 
 let readSourceDirs = (~configSources) => {
   let sourceDirs =
-    ["lib", "bs", ".sourcedirs.json"] |> List.fold_left((+++), bsbProjectRoot^);
+    ["lib", "bs", ".sourcedirs.json"]
+    |> List.fold_left((+++), bsbProjectRoot^);
   let dirs = ref([]);
   let pkgs = Hashtbl.create(1);
 
@@ -200,31 +201,29 @@ let sourcedirsJsonToMap = (~config, ~extensions, ~excludeFile) => {
        )
      );
 
-  if (config.useBsDependencies) {
-    config.bsDependencies
-    |> List.iter(packageName => {
-         switch (Hashtbl.find(pkgs, packageName)) {
-         | path =>
-           let root = ["lib", "bs"] |> List.fold_left((+++), path);
-           let filter = fileName =>
-             [".cmt", ".cmti"]
-             |> List.exists(ext => Filename.check_suffix(fileName, ext));
-           readBsDependenciesDirs(~root)
-           |> List.iter(dir => {
-                let dirOnDisk = root +++ dir;
-                let dirEmitted = packageName +++ dir;
-                addDir(
-                  ~dirEmitted,
-                  ~dirOnDisk,
-                  ~filter,
-                  ~map=bsDependenciesFileMap,
-                  ~root=projectRoot^,
-                );
-              });
-         | exception Not_found => ()
-         }
-       });
-  };
+  config.bsDependencies
+  |> List.iter(packageName => {
+       switch (Hashtbl.find(pkgs, packageName)) {
+       | path =>
+         let root = ["lib", "bs"] |> List.fold_left((+++), path);
+         let filter = fileName =>
+           [".cmt", ".cmti"]
+           |> List.exists(ext => Filename.check_suffix(fileName, ext));
+         readBsDependenciesDirs(~root)
+         |> List.iter(dir => {
+              let dirOnDisk = root +++ dir;
+              let dirEmitted = packageName +++ dir;
+              addDir(
+                ~dirEmitted,
+                ~dirOnDisk,
+                ~filter,
+                ~map=bsDependenciesFileMap,
+                ~root=projectRoot^,
+              );
+            });
+       | exception Not_found => ()
+       }
+     });
 
   (fileMap^, bsDependenciesFileMap^);
 };


### PR DESCRIPTION
Turn on support for dependent projects by default.
Document the feature.