### PR TITLE
Support @bs.as to rename record fields.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,8 @@
 # master
+- Add support for `@bs.as` to rename record fields (from bukclescript 7.0.0).
+  At that point, use of `@genType.as` on record fields will be discouraged,
+  as it incurs the extra cost of runtime conversion.
+  But it will be kept for backwards compatibility for existing code.
 
 # 3.4.4
 - Add support for bucklescript dependencies, specified in `bs-dependencies`.

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Similarly, to import a value with a different JS name, use e.g. `[@genType.impor
 
 To import nested values, e.g. `Some.Nested.value`, use e.g. `[@genType.import ("./MyMath", "Some.Nested.value")]`.
 
-### Export and Import React Components
+### Export and Import React Components Using Deprecated Record API
 
 To export a ReasonReact component to JS, and automatically generate a wrapper for it, simply annotate the `make` function:
 

--- a/README.md
+++ b/README.md
@@ -244,6 +244,10 @@ type persons = array(person);
 ### Renaming, @genType.as, and object mangling convention.
 
 By default, entities with a given name are exported/imported with the same name. However, you might wish to change the appearence of the name on the JS side.
+
+**NOTE** From bucklescript 7.0.0, `@genType.as` on record fields will be discouraged,
+as it incurs a runtime conversion cost. Instead `@bs.as` will be supported and incur zero cost.
+
 For example, in case of a record field whose name is a keyword, such as `type`:
 
 ```reason

--- a/examples/typescript-react-example/deadcode.txt
+++ b/examples/typescript-react-example/deadcode.txt
@@ -1216,6 +1216,9 @@
   addValueReference Records.re:155:4 --> Records.re:155:17
   addValueReference Records.re:155:4 --> js.ml:70:1
   addValueReference Records.re:158:4 --> Records.re:158:18
+  [type] addTypeReference Records.re:167:38 --> Records.re:162:2
+  addValueReference Records.re:167:4 --> Records.re:167:21
+  addValueReference Records.re:170:4 --> Records.re:170:22
   [type] export x Records.re:5:2
   [type] export y Records.re:6:2
   [type] export z Records.re:7:2
@@ -1253,6 +1256,9 @@
   export testMyRec2 Records.re:152:4
   export testMyObj Records.re:155:4
   export testMyObj2 Records.re:158:4
+  [type] export type_ Records.re:162:2
+  export testMyRecBsAs Records.re:167:4
+  export testMyRecBsAs2 Records.re:170:4
   Scanning /Users/cristianoc/reasonml/genType/examples/typescript-react-example/lib/bs/src/ImportIndex.cmt
   export make ImportIndex.re:1:0
   Scanning /Users/cristianoc/reasonml/genType/examples/typescript-react-example/lib/bs/src/Hooks.cmt

--- a/examples/typescript-react-example/src/Records.bs.js
+++ b/examples/typescript-react-example/src/Records.bs.js
@@ -123,6 +123,14 @@ function testMyObj2(x) {
   return x;
 }
 
+function testMyRecBsAs(x) {
+  return x[/* type_ */0];
+}
+
+function testMyRecBsAs2(x) {
+  return x;
+}
+
 var origin = /* record */[
   /* x */0,
   /* y */0,
@@ -156,6 +164,8 @@ export {
   testMyRec2 ,
   testMyObj ,
   testMyObj2 ,
+  testMyRecBsAs ,
+  testMyRecBsAs2 ,
   
 }
 /* No side effect */

--- a/examples/typescript-react-example/src/Records.gen.tsx
+++ b/examples/typescript-react-example/src/Records.gen.tsx
@@ -60,6 +60,9 @@ export type myRec = { readonly type: string };
 // tslint:disable-next-line:interface-over-type-literal
 export type myObj = { readonly type_: string };
 
+// tslint:disable-next-line:interface-over-type-literal
+export type myRecBsAs = { readonly type_: string };
+
 export const origin: coord = {x:RecordsBS.origin[0], y:RecordsBS.origin[1], z:RecordsBS.origin[2]};
 
 export const computeArea: (_1:coord) => number = function (Arg1: any) {
@@ -135,3 +138,13 @@ export const testMyRec2: (_1:myRec) => myRec = function (Arg1: any) {
 export const testMyObj: (_1:myObj) => string = RecordsBS.testMyObj;
 
 export const testMyObj2: (_1:myObj) => myObj = RecordsBS.testMyObj2;
+
+export const testMyRecBsAs: (_1:myRecBsAs) => string = function (Arg1: any) {
+  const result = RecordsBS.testMyRecBsAs([Arg1.type_]);
+  return result
+};
+
+export const testMyRecBsAs2: (_1:myRecBsAs) => myRecBsAs = function (Arg1: any) {
+  const result = RecordsBS.testMyRecBsAs2([Arg1.type_]);
+  return {type_:result[0]}
+};

--- a/examples/typescript-react-example/src/Records.re
+++ b/examples/typescript-react-example/src/Records.re
@@ -156,3 +156,15 @@ let testMyObj = (x: myObj) => x##type_;
 
 [@genType]
 let testMyObj2 = (x: myObj) => x;
+
+[@genType]
+type myRecBsAs = {
+  [@bs.as "type"]
+  type_: string,
+};
+
+[@genType]
+let testMyRecBsAs = (x: myRecBsAs) => x.type_;
+
+[@genType]
+let testMyRecBsAs2 = (x: myRecBsAs) => x;

--- a/src/Annotation.re
+++ b/src/Annotation.re
@@ -26,6 +26,8 @@ let toString = annotation =>
 let tagIsGenType = s => s == "genType" || s == "gentype";
 let tagIsGenTypeAs = s => s == "genType.as" || s == "gentype.as";
 
+let tagIsBsAs = s => s == "bs.as";
+
 let tagIsGenTypeImport = s => s == "genType.import" || s == "gentype.import";
 
 let tagIsGenTypeOpaque = s => s == "genType.opaque" || s == "gentype.opaque";
@@ -70,26 +72,20 @@ let rec getAttributePayload = (checkText, attributes: Typedtree.attributes) => {
     | PStr([{pstr_desc: Pstr_eval(expr, _)}, ..._]) => expr |> fromExpr
     | PStr([{pstr_desc: Pstr_extension(_)}, ..._]) =>
       Some(UnrecognizedPayload)
-    | PStr([{pstr_desc: Pstr_value(_)}, ..._]) =>
-      Some(UnrecognizedPayload)
+    | PStr([{pstr_desc: Pstr_value(_)}, ..._]) => Some(UnrecognizedPayload)
     | PStr([{pstr_desc: Pstr_primitive(_)}, ..._]) =>
       Some(UnrecognizedPayload)
-    | PStr([{pstr_desc: Pstr_type(_)}, ..._]) =>
-      Some(UnrecognizedPayload)
-    | PStr([{pstr_desc: Pstr_typext(_)}, ..._]) =>
-      Some(UnrecognizedPayload)
+    | PStr([{pstr_desc: Pstr_type(_)}, ..._]) => Some(UnrecognizedPayload)
+    | PStr([{pstr_desc: Pstr_typext(_)}, ..._]) => Some(UnrecognizedPayload)
     | PStr([{pstr_desc: Pstr_exception(_)}, ..._]) =>
       Some(UnrecognizedPayload)
-    | PStr([{pstr_desc: Pstr_module(_)}, ..._]) =>
-      Some(UnrecognizedPayload)
+    | PStr([{pstr_desc: Pstr_module(_)}, ..._]) => Some(UnrecognizedPayload)
     | PStr([{pstr_desc: Pstr_recmodule(_)}, ..._]) =>
       Some(UnrecognizedPayload)
     | PStr([{pstr_desc: Pstr_modtype(_)}, ..._]) =>
       Some(UnrecognizedPayload)
-    | PStr([{pstr_desc: Pstr_open(_)}, ..._]) =>
-      Some(UnrecognizedPayload)
-    | PStr([{pstr_desc: Pstr_class(_)}, ..._]) =>
-      Some(UnrecognizedPayload)
+    | PStr([{pstr_desc: Pstr_open(_)}, ..._]) => Some(UnrecognizedPayload)
+    | PStr([{pstr_desc: Pstr_class(_)}, ..._]) => Some(UnrecognizedPayload)
     | PStr([{pstr_desc: Pstr_class_type(_)}, ..._]) =>
       Some(UnrecognizedPayload)
     | PStr([{pstr_desc: Pstr_include(_)}, ..._]) =>
@@ -112,6 +108,12 @@ let getGenTypeAsRenaming = attributes =>
     | Some(StringPayload(s)) => Some(s)
     | _ => None
     }
+  | _ => None
+  };
+
+let getBsAsRenaming = attributes =>
+  switch (attributes |> getAttributePayload(tagIsBsAs)) {
+  | Some(StringPayload(s)) => Some(s)
   | _ => None
   };
 
@@ -262,7 +264,7 @@ let importFromString = (importString): import => {
   let name = {
     let base = importString |> Filename.basename;
     (
-      try (base |> Filename.chop_extension) {
+      try(base |> Filename.chop_extension) {
       | Invalid_argument(_) => base
       }
     )

--- a/src/Annotation.re
+++ b/src/Annotation.re
@@ -104,7 +104,7 @@ let rec getAttributePayload = (checkText, attributes: Typedtree.attributes) => {
   };
 };
 
-let getAttributeRenaming = attributes =>
+let getGenTypeAsRenaming = attributes =>
   switch (attributes |> getAttributePayload(tagIsGenTypeAs)) {
   | Some(StringPayload(s)) => Some(s)
   | None =>
@@ -117,11 +117,11 @@ let getAttributeRenaming = attributes =>
 
 let getAttributeImportRenaming = attributes => {
   let attributeImport = attributes |> getAttributePayload(tagIsGenTypeImport);
-  let attributeRenaming = attributes |> getAttributeRenaming;
-  switch (attributeImport, attributeRenaming) {
+  let genTypeAsRenaming = attributes |> getGenTypeAsRenaming;
+  switch (attributeImport, genTypeAsRenaming) {
   | (Some(StringPayload(importString)), _) => (
       Some(importString),
-      attributeRenaming,
+      genTypeAsRenaming,
     )
   | (
       Some(
@@ -135,7 +135,7 @@ let getAttributeImportRenaming = attributes => {
       Some(importString),
       Some(renameString),
     )
-  | _ => (None, attributeRenaming)
+  | _ => (None, genTypeAsRenaming)
   };
 };
 

--- a/src/Annotation.re
+++ b/src/Annotation.re
@@ -36,18 +36,18 @@ let tagIsGenTypeIgnoreInterface = s =>
 let rec getAttributePayload = (checkText, attributes: Typedtree.attributes) => {
   let rec fromExpr = (expr: Parsetree.expression) =>
     switch (expr) {
-    | {pexp_desc: Pexp_constant(Pconst_string(s, _)), _} =>
+    | {pexp_desc: Pexp_constant(Pconst_string(s, _))} =>
       Some(StringPayload(s))
-    | {pexp_desc: Pexp_constant(Pconst_integer(n, _)), _} =>
+    | {pexp_desc: Pexp_constant(Pconst_integer(n, _))} =>
       Some(IntPayload(n))
-    | {pexp_desc: Pexp_constant(Pconst_float(s, _)), _} =>
+    | {pexp_desc: Pexp_constant(Pconst_float(s, _))} =>
       Some(FloatPayload(s))
     | {
         pexp_desc: Pexp_construct({txt: Lident(("true" | "false") as s)}, _),
         _,
       } =>
       Some(BoolPayload(s == "true"))
-    | {pexp_desc: Pexp_tuple(exprs), _} =>
+    | {pexp_desc: Pexp_tuple(exprs)} =>
       let payloads =
         exprs
         |> List.rev
@@ -64,37 +64,37 @@ let rec getAttributePayload = (checkText, attributes: Typedtree.attributes) => {
     };
   switch (attributes) {
   | [] => None
-  | [({Asttypes.txt, _}, payload), ..._tl] when checkText(txt) =>
+  | [({Asttypes.txt}, payload), ..._tl] when checkText(txt) =>
     switch (payload) {
     | PStr([]) => Some(UnrecognizedPayload)
-    | PStr([{pstr_desc: Pstr_eval(expr, _), _}, ..._]) => expr |> fromExpr
-    | PStr([{pstr_desc: Pstr_extension(_), _}, ..._]) =>
+    | PStr([{pstr_desc: Pstr_eval(expr, _)}, ..._]) => expr |> fromExpr
+    | PStr([{pstr_desc: Pstr_extension(_)}, ..._]) =>
       Some(UnrecognizedPayload)
-    | PStr([{pstr_desc: Pstr_value(_), _}, ..._]) =>
+    | PStr([{pstr_desc: Pstr_value(_)}, ..._]) =>
       Some(UnrecognizedPayload)
-    | PStr([{pstr_desc: Pstr_primitive(_), _}, ..._]) =>
+    | PStr([{pstr_desc: Pstr_primitive(_)}, ..._]) =>
       Some(UnrecognizedPayload)
-    | PStr([{pstr_desc: Pstr_type(_), _}, ..._]) =>
+    | PStr([{pstr_desc: Pstr_type(_)}, ..._]) =>
       Some(UnrecognizedPayload)
-    | PStr([{pstr_desc: Pstr_typext(_), _}, ..._]) =>
+    | PStr([{pstr_desc: Pstr_typext(_)}, ..._]) =>
       Some(UnrecognizedPayload)
-    | PStr([{pstr_desc: Pstr_exception(_), _}, ..._]) =>
+    | PStr([{pstr_desc: Pstr_exception(_)}, ..._]) =>
       Some(UnrecognizedPayload)
-    | PStr([{pstr_desc: Pstr_module(_), _}, ..._]) =>
+    | PStr([{pstr_desc: Pstr_module(_)}, ..._]) =>
       Some(UnrecognizedPayload)
-    | PStr([{pstr_desc: Pstr_recmodule(_), _}, ..._]) =>
+    | PStr([{pstr_desc: Pstr_recmodule(_)}, ..._]) =>
       Some(UnrecognizedPayload)
-    | PStr([{pstr_desc: Pstr_modtype(_), _}, ..._]) =>
+    | PStr([{pstr_desc: Pstr_modtype(_)}, ..._]) =>
       Some(UnrecognizedPayload)
-    | PStr([{pstr_desc: Pstr_open(_), _}, ..._]) =>
+    | PStr([{pstr_desc: Pstr_open(_)}, ..._]) =>
       Some(UnrecognizedPayload)
-    | PStr([{pstr_desc: Pstr_class(_), _}, ..._]) =>
+    | PStr([{pstr_desc: Pstr_class(_)}, ..._]) =>
       Some(UnrecognizedPayload)
-    | PStr([{pstr_desc: Pstr_class_type(_), _}, ..._]) =>
+    | PStr([{pstr_desc: Pstr_class_type(_)}, ..._]) =>
       Some(UnrecognizedPayload)
-    | PStr([{pstr_desc: Pstr_include(_), _}, ..._]) =>
+    | PStr([{pstr_desc: Pstr_include(_)}, ..._]) =>
       Some(UnrecognizedPayload)
-    | PStr([{pstr_desc: Pstr_attribute(_), _}, ..._]) =>
+    | PStr([{pstr_desc: Pstr_attribute(_)}, ..._]) =>
       Some(UnrecognizedPayload)
     | PPat(_) => Some(UnrecognizedPayload)
     | PSig(_) => Some(UnrecognizedPayload)
@@ -162,7 +162,7 @@ let hasGenTypeAnnotation = (~ignoreInterface, attributes) => {
 };
 
 let rec moduleTypeHasGenTypeAnnotation =
-        (~ignoreInterface, {mty_desc, _}: Typedtree.module_type) =>
+        (~ignoreInterface, {mty_desc}: Typedtree.module_type) =>
   switch (mty_desc) {
   | Tmty_signature(signature) =>
     signature |> signatureHasGenTypeAnnotation(~ignoreInterface)
@@ -175,7 +175,7 @@ let rec moduleTypeHasGenTypeAnnotation =
 and moduleDeclarationHasGenTypeAnnotation =
     (
       ~ignoreInterface,
-      {md_attributes, md_type, _}: Typedtree.module_declaration,
+      {md_attributes, md_type}: Typedtree.module_declaration,
     ) =>
   md_attributes
   |> hasGenTypeAnnotation(~ignoreInterface)
@@ -184,18 +184,18 @@ and moduleDeclarationHasGenTypeAnnotation =
 and signatureItemHasGenTypeAnnotation =
     (~ignoreInterface, signatureItem: Typedtree.signature_item) =>
   switch (signatureItem) {
-  | {Typedtree.sig_desc: Typedtree.Tsig_type(_, typeDeclarations), _} =>
+  | {Typedtree.sig_desc: Typedtree.Tsig_type(_, typeDeclarations)} =>
     typeDeclarations
     |> List.exists(dec =>
          dec.Typedtree.typ_attributes
          |> hasGenTypeAnnotation(~ignoreInterface)
        )
-  | {sig_desc: Tsig_value(valueDescription), _} =>
+  | {sig_desc: Tsig_value(valueDescription)} =>
     valueDescription.val_attributes |> hasGenTypeAnnotation(~ignoreInterface)
-  | {sig_desc: Tsig_module(moduleDeclaration), _} =>
+  | {sig_desc: Tsig_module(moduleDeclaration)} =>
     moduleDeclaration
     |> moduleDeclarationHasGenTypeAnnotation(~ignoreInterface)
-  | {sig_desc: Tsig_attribute(attribute), _} =>
+  | {sig_desc: Tsig_attribute(attribute)} =>
     [attribute] |> hasGenTypeAnnotation(~ignoreInterface)
   | _ => false
   }
@@ -207,25 +207,25 @@ and signatureHasGenTypeAnnotation =
 let rec structureItemHasGenTypeAnnotation =
         (~ignoreInterface, structureItem: Typedtree.structure_item) =>
   switch (structureItem) {
-  | {Typedtree.str_desc: Typedtree.Tstr_type(_, typeDeclarations), _} =>
+  | {Typedtree.str_desc: Typedtree.Tstr_type(_, typeDeclarations)} =>
     typeDeclarations
     |> List.exists(dec =>
          dec.Typedtree.typ_attributes
          |> hasGenTypeAnnotation(~ignoreInterface)
        )
-  | {str_desc: Tstr_value(_loc, valueBindings), _} =>
+  | {str_desc: Tstr_value(_loc, valueBindings)} =>
     valueBindings
     |> List.exists(vb =>
          vb.Typedtree.vb_attributes |> hasGenTypeAnnotation(~ignoreInterface)
        )
-  | {str_desc: Tstr_primitive(valueDescription), _} =>
+  | {str_desc: Tstr_primitive(valueDescription)} =>
     valueDescription.val_attributes |> hasGenTypeAnnotation(~ignoreInterface)
-  | {str_desc: Tstr_module(moduleBinding), _} =>
+  | {str_desc: Tstr_module(moduleBinding)} =>
     moduleBinding |> moduleBindingHasGenTypeAnnotation(~ignoreInterface)
-  | {str_desc: Tstr_recmodule(moduleBindings), _} =>
+  | {str_desc: Tstr_recmodule(moduleBindings)} =>
     moduleBindings
     |> List.exists(moduleBindingHasGenTypeAnnotation(~ignoreInterface))
-  | {str_desc: Tstr_include({incl_attributes, incl_mod}), _} =>
+  | {str_desc: Tstr_include({incl_attributes, incl_mod})} =>
     incl_attributes
     |> hasGenTypeAnnotation(~ignoreInterface)
     || incl_mod
@@ -245,7 +245,7 @@ and moduleExprHasGenTypeAnnotation =
   | Tmod_unpack(_) => false
   }
 and moduleBindingHasGenTypeAnnotation =
-    (~ignoreInterface, {mb_expr, mb_attributes, _}: Typedtree.module_binding) =>
+    (~ignoreInterface, {mb_expr, mb_attributes}: Typedtree.module_binding) =>
   mb_attributes
   |> hasGenTypeAnnotation(~ignoreInterface)
   || mb_expr

--- a/src/DeadType.re
+++ b/src/DeadType.re
@@ -21,11 +21,11 @@ let collectTypeExport =
   switch (type_kind) {
   | Type_record(l, _) =>
     List.iter(
-      ({Types.ld_id, ld_loc, ld_type, _}) => save(ld_id, ld_loc),
+      ({Types.ld_id, ld_loc, ld_type}) => save(ld_id, ld_loc),
       l,
     )
   | Type_variant(l) =>
-    List.iter(({Types.cd_id, cd_loc, _}) => save(cd_id, cd_loc), l)
+    List.iter(({Types.cd_id, cd_loc}) => save(cd_id, cd_loc), l)
   | _ => ()
   };
 };
@@ -56,7 +56,7 @@ let processTypeDeclaration = (typeDeclaration: Typedtree.type_declaration) => {
 
     try(
       switch (typeDeclaration.typ_manifest) {
-      | Some({ctyp_desc: Ttyp_constr(_, {txt, _}, _), _}) =>
+      | Some({ctyp_desc: Ttyp_constr(_, {txt}, _)}) =>
         let pos1 =
           Hashtbl.find(
             fields,

--- a/src/DeadValue.re
+++ b/src/DeadValue.re
@@ -30,8 +30,8 @@ let rec collectExportFromSignatureItem = (~path, si: Types.signature_item) =>
       DeadType.collectTypeExport(~path=[id, ...path], t);
     }
   | (
-      Sig_module(id, {Types.md_type: moduleType, _}, _) |
-      Sig_modtype(id, {Types.mtd_type: Some(moduleType), _})
+      Sig_module(id, {Types.md_type: moduleType}, _) |
+      Sig_modtype(id, {Types.mtd_type: Some(moduleType)})
     ) as s =>
     let collect =
       switch (s) {
@@ -81,14 +81,14 @@ let collectExpr = (super, self, e: Typedtree.expression) => {
       _,
       x,
       {
-        lbl_loc: {Location.loc_start: posDeclaration, loc_ghost: false, _},
+        lbl_loc: {Location.loc_start: posDeclaration, loc_ghost: false},
         _,
       },
     )
   | Texp_construct(
       x,
       {
-        cstr_loc: {Location.loc_start: posDeclaration, loc_ghost: false, _},
+        cstr_loc: {Location.loc_start: posDeclaration, loc_ghost: false},
         _,
       },
       _,

--- a/src/EmitType.re
+++ b/src/EmitType.re
@@ -261,7 +261,7 @@ let rec renderType =
     ++ "]"
   | TypeVar(s) => s
 
-  | Variant({noPayloads, payloads, unboxed, _}) =>
+  | Variant({noPayloads, payloads, unboxed}) =>
     let noPayloadsRendered =
       noPayloads |> List.map(case => case.labelJS |> labelJSToString);
     let field = (~name, value) => {

--- a/src/GenTypeMain.re
+++ b/src/GenTypeMain.re
@@ -39,7 +39,7 @@ let signatureItemIsDeclaration = signatureItem =>
 
 let inputCmtTranslateTypeDeclarations =
     (~config, ~outputFileRelative, ~resolver, inputCMT): CodeItem.translation => {
-  let {Cmt_format.cmt_annots, _} = inputCMT;
+  let {Cmt_format.cmt_annots} = inputCMT;
   let typeEnv = TypeEnv.root();
   let translations =
     switch (cmt_annots) {
@@ -80,7 +80,7 @@ let inputCmtTranslateTypeDeclarations =
 
 let translateCMT =
     (~config, ~outputFileRelative, ~resolver, inputCMT): Translation.t => {
-  let {Cmt_format.cmt_annots, _} = inputCMT;
+  let {Cmt_format.cmt_annots} = inputCMT;
   let typeEnv = TypeEnv.root();
   let translations =
     switch (cmt_annots) {

--- a/src/TranslateCoreType.re
+++ b/src/TranslateCoreType.re
@@ -86,7 +86,7 @@ let rec translateArrowType =
        );
   | Ttyp_arrow((Labelled(lbl) | Optional(lbl)) as label, coreType1, coreType2) =>
     let asLabel =
-      switch (coreType.ctyp_attributes |> Annotation.getAttributeRenaming) {
+      switch (coreType.ctyp_attributes |> Annotation.getGenTypeAsRenaming) {
       | Some(s) => s
       | None => ""
       };

--- a/src/TranslateCoreType.re
+++ b/src/TranslateCoreType.re
@@ -176,7 +176,7 @@ and translateCoreType_ =
        )
 
   | Ttyp_constr(
-      Pdot(Pident({name: "Js", _}), "t", _) as path,
+      Pdot(Pident({name: "Js"}), "t", _) as path,
       _,
       [
         {
@@ -246,10 +246,10 @@ and translateCoreType_ =
     let innerTypesTranslation =
       listExp |> translateCoreTypes_(~config, ~typeVarsGen, ~typeEnv);
     let innerTypes =
-      innerTypesTranslation |> List.map(({type_, _}) => type_);
+      innerTypesTranslation |> List.map(({type_}) => type_);
     let innerTypesDeps =
       innerTypesTranslation
-      |> List.map(({dependencies, _}) => dependencies)
+      |> List.map(({dependencies}) => dependencies)
       |> List.concat;
 
     let tupleType = Tuple(innerTypes);
@@ -288,7 +288,7 @@ and translateCoreType_ =
       let type_ = createVariant(~noPayloads, ~payloads, ~polymorphic=true);
       let dependencies =
         payloadsTranslations
-        |> List.map(((_, _, {dependencies, _})) => dependencies)
+        |> List.map(((_, _, {dependencies})) => dependencies)
         |> List.concat;
       {dependencies, type_};
 

--- a/src/TranslateSignature.re
+++ b/src/TranslateSignature.re
@@ -9,7 +9,7 @@ let translateSignatureValue =
       valueDescription: Typedtree.value_description,
     )
     : Translation.t => {
-  let {Typedtree.val_id, val_desc, val_attributes, _} = valueDescription;
+  let {Typedtree.val_id, val_desc, val_attributes} = valueDescription;
   if (Debug.translation^) {
     logItem("Translate Signature Value %s\n", val_id |> Ident.name);
   };
@@ -40,7 +40,7 @@ let rec translateModuleDeclaration =
           ~outputFileRelative,
           ~resolver,
           ~typeEnv,
-          {md_id, md_type, _}: Typedtree.module_declaration,
+          {md_id, md_type}: Typedtree.module_declaration,
         ) => {
   let name = md_id |> Ident.name;
   if (Debug.translation^) {
@@ -97,8 +97,8 @@ and translateModuleTypeDeclaration =
     );
   };
   switch (moduleTypeDeclaration) {
-  | {mtd_type: None, _} => Translation.empty
-  | {mtd_id, mtd_type: Some(mtd_type), _} =>
+  | {mtd_type: None} => Translation.empty
+  | {mtd_id, mtd_type: Some(mtd_type)} =>
     switch (mtd_type.mty_desc) {
     | Tmty_signature(signature) =>
       let name = mtd_id |> Ident.name;
@@ -142,7 +142,7 @@ and translateSignatureItem =
     )
     : Translation.t =>
   switch (signatureItem) {
-  | {Typedtree.sig_desc: Typedtree.Tsig_type(_, typeDeclarations), _} => {
+  | {Typedtree.sig_desc: Typedtree.Tsig_type(_, typeDeclarations)} => {
       importTypes: [],
       codeItems: [],
       typeDeclarations:
@@ -155,7 +155,7 @@ and translateSignatureItem =
            ),
     }
 
-  | {Typedtree.sig_desc: Tsig_value(valueDescription), _} =>
+  | {Typedtree.sig_desc: Tsig_value(valueDescription)} =>
     if (valueDescription.val_prim != []) {
       valueDescription
       |> Translation.translatePrimitive(
@@ -178,7 +178,7 @@ and translateSignatureItem =
          );
     }
 
-  | {Typedtree.sig_desc: Typedtree.Tsig_module(moduleDeclaration), _} =>
+  | {Typedtree.sig_desc: Typedtree.Tsig_module(moduleDeclaration)} =>
     moduleDeclaration
     |> translateModuleDeclaration(
          ~config,
@@ -187,7 +187,7 @@ and translateSignatureItem =
          ~typeEnv,
        )
 
-  | {Typedtree.sig_desc: Typedtree.Tsig_modtype(moduleTypeDeclaration), _} =>
+  | {Typedtree.sig_desc: Typedtree.Tsig_modtype(moduleTypeDeclaration)} =>
     let moduleItem =
       moduleItemGen
       |> Runtime.newModuleItem(
@@ -202,28 +202,28 @@ and translateSignatureItem =
          ~typeEnv,
        );
 
-  | {Typedtree.sig_desc: Typedtree.Tsig_typext(_), _} =>
+  | {Typedtree.sig_desc: Typedtree.Tsig_typext(_)} =>
     logNotImplemented("Tsig_typext " ++ __LOC__);
     Translation.empty;
-  | {Typedtree.sig_desc: Typedtree.Tsig_exception(_), _} =>
+  | {Typedtree.sig_desc: Typedtree.Tsig_exception(_)} =>
     logNotImplemented("Tsig_exception " ++ __LOC__);
     Translation.empty;
-  | {Typedtree.sig_desc: Typedtree.Tsig_recmodule(_), _} =>
+  | {Typedtree.sig_desc: Typedtree.Tsig_recmodule(_)} =>
     logNotImplemented("Tsig_recmodule " ++ __LOC__);
     Translation.empty;
-  | {Typedtree.sig_desc: Typedtree.Tsig_open(_), _} =>
+  | {Typedtree.sig_desc: Typedtree.Tsig_open(_)} =>
     logNotImplemented("Tsig_open " ++ __LOC__);
     Translation.empty;
-  | {Typedtree.sig_desc: Typedtree.Tsig_include(_), _} =>
+  | {Typedtree.sig_desc: Typedtree.Tsig_include(_)} =>
     logNotImplemented("Tsig_include " ++ __LOC__);
     Translation.empty;
-  | {Typedtree.sig_desc: Typedtree.Tsig_class(_), _} =>
+  | {Typedtree.sig_desc: Typedtree.Tsig_class(_)} =>
     logNotImplemented("Tsig_class " ++ __LOC__);
     Translation.empty;
-  | {Typedtree.sig_desc: Typedtree.Tsig_class_type(_), _} =>
+  | {Typedtree.sig_desc: Typedtree.Tsig_class_type(_)} =>
     logNotImplemented("Tsig_class_type " ++ __LOC__);
     Translation.empty;
-  | {Typedtree.sig_desc: Typedtree.Tsig_attribute(_), _} =>
+  | {Typedtree.sig_desc: Typedtree.Tsig_attribute(_)} =>
     logNotImplemented("Tsig_attribute " ++ __LOC__);
     Translation.empty;
   }

--- a/src/TranslateSignatureFromTypes.re
+++ b/src/TranslateSignatureFromTypes.re
@@ -8,7 +8,7 @@ let translateTypeDeclarationFromTypes =
       ~resolver,
       ~typeEnv,
       ~id,
-      {type_params, type_kind, type_attributes, type_manifest, _}: Types.type_declaration,
+      {type_params, type_kind, type_attributes, type_manifest}: Types.type_declaration,
     )
     : list(CodeItem.typeDeclaration) => {
   typeEnv |> TypeEnv.newType(~name=id |> Ident.name);

--- a/src/TranslateStructure.re
+++ b/src/TranslateStructure.re
@@ -24,6 +24,7 @@ and addAnnotationsToFields =
     | Some(StringPayload(s)) =>
       let (nextFields1, types1) =
         addAnnotationsToFields(c_rhs, nextFields, types);
+      // TODO: support @bs.as
       ([{...field, nameJS: s}, ...nextFields1], types1);
     | _ =>
       let (nextFields1, types1) =

--- a/src/TranslateStructure.re
+++ b/src/TranslateStructure.re
@@ -17,20 +17,15 @@ and addAnnotationsToFields =
   switch (expr.exp_desc, fields, types) {
   | (_, [], _) => ([], types |> addAnnotationsToTypes(~expr))
   | (Texp_function({cases: [{c_rhs}]}), [field, ...nextFields], _) =>
-    let genTypeAsPayload =
-      expr.exp_attributes
-      |> Annotation.getAttributePayload(Annotation.tagIsGenTypeAs);
-    switch (genTypeAsPayload) {
-    | Some(StringPayload(s)) =>
-      let (nextFields1, types1) =
-        addAnnotationsToFields(c_rhs, nextFields, types);
-      // TODO: support @bs.as
-      ([{...field, nameJS: s}, ...nextFields1], types1);
-    | _ =>
-      let (nextFields1, types1) =
-        addAnnotationsToFields(c_rhs, nextFields, types);
-      ([field, ...nextFields1], types1);
-    };
+    let (nextFields1, types1) =
+      addAnnotationsToFields(c_rhs, nextFields, types);
+    let (nameJS, nameRE) =
+      TranslateTypeDeclarations.renameRecordField(
+        ~attributes=expr.exp_attributes,
+        ~nameRE=field.nameRE,
+      );
+    ([{...field, nameJS, nameRE}, ...nextFields1], types1);
+
   | _ => (fields, types)
   };
 

--- a/src/TranslateTypeDeclarations.re
+++ b/src/TranslateTypeDeclarations.re
@@ -80,7 +80,7 @@ let traslateDeclarationKind =
   let translateLabelDeclarations = labelDeclarations => {
     let fieldTranslations =
       labelDeclarations
-      |> List.map(({Types.ld_id, ld_mutable, ld_type, ld_attributes, _}) => {
+      |> List.map(({Types.ld_id, ld_mutable, ld_type, ld_attributes}) => {
            let nameRE = ld_id |> Ident.name;
            let nameJS =
              // TODO: support @bs.as
@@ -103,7 +103,7 @@ let traslateDeclarationKind =
 
     let dependencies =
       fieldTranslations
-      |> List.map(((_, _, _, {TranslateTypeExprFromTypes.dependencies, _})) =>
+      |> List.map(((_, _, _, {TranslateTypeExprFromTypes.dependencies})) =>
            dependencies
          )
       |> List.concat;
@@ -116,7 +116,7 @@ let traslateDeclarationKind =
                nameJS,
                nameRE,
                mutable_,
-               {TranslateTypeExprFromTypes.type_, _},
+               {TranslateTypeExprFromTypes.type_},
              ),
            ) => {
            let (optional, type1) =
@@ -196,7 +196,7 @@ let traslateDeclarationKind =
       coreType |> TranslateCoreType.translateCoreType(~config, ~typeEnv);
     let type_ =
       switch (coreType, translation.type_) {
-      | ({ctyp_desc: Ttyp_variant(rowFields, _, _), _}, Variant(variant)) =>
+      | ({ctyp_desc: Ttyp_variant(rowFields, _, _)}, Variant(variant)) =>
         let rowFieldsVariants = rowFields |> TranslateCoreType.processVariant;
         let noPayloads = rowFieldsVariants.noPayloads |> List.map(createCase);
         let payloads =
@@ -273,10 +273,10 @@ let traslateDeclarationKind =
 
            let argTypes =
              argsTranslation
-             |> List.map(({TranslateTypeExprFromTypes.type_, _}) => type_);
+             |> List.map(({TranslateTypeExprFromTypes.type_}) => type_);
            let importTypes =
              argsTranslation
-             |> List.map(({TranslateTypeExprFromTypes.dependencies, _}) =>
+             |> List.map(({TranslateTypeExprFromTypes.dependencies}) =>
                   dependencies
                 )
              |> List.concat
@@ -382,7 +382,7 @@ let translateTypeDeclaration =
       ~outputFileRelative,
       ~resolver,
       ~typeEnv,
-      {typ_attributes, typ_id, typ_manifest, typ_params, typ_type, _}: Typedtree.type_declaration,
+      {typ_attributes, typ_id, typ_manifest, typ_params, typ_type}: Typedtree.type_declaration,
     )
     : list(CodeItem.typeDeclaration) => {
   if (Debug.translation^) {

--- a/src/TranslateTypeDeclarations.re
+++ b/src/TranslateTypeDeclarations.re
@@ -37,6 +37,9 @@ let createCase = ((label, attributes)) =>
 let renameRecordField = (~attributes, ~nameRE) => {
   let nameJS =
     // TODO: support @bs.as
+    // Ignore @bs.as unless recordsAsObjects is active
+    // Need to keep genType.as for backwards compatibility
+    // If both genType.as and bs.as are present, decide on priority
     switch (attributes |> Annotation.getAttributeRenaming) {
     | Some(s) => s
     | None => nameRE

--- a/src/TranslateTypeDeclarations.re
+++ b/src/TranslateTypeDeclarations.re
@@ -83,6 +83,7 @@ let traslateDeclarationKind =
       |> List.map(({Types.ld_id, ld_mutable, ld_type, ld_attributes, _}) => {
            let nameRE = ld_id |> Ident.name;
            let nameJS =
+             // TODO: support @bs.as
              switch (ld_attributes |> Annotation.getAttributeRenaming) {
              | Some(s) => s
              | None => nameRE

--- a/src/TranslateTypeDeclarations.re
+++ b/src/TranslateTypeDeclarations.re
@@ -40,7 +40,7 @@ let renameRecordField = (~attributes, ~nameRE) => {
     // Ignore @bs.as unless recordsAsObjects is active
     // Need to keep genType.as for backwards compatibility
     // If both genType.as and bs.as are present, decide on priority
-    switch (attributes |> Annotation.getAttributeRenaming) {
+    switch (attributes |> Annotation.getGenTypeAsRenaming) {
     | Some(s) => s
     | None => nameRE
     };

--- a/src/TranslateTypeExprFromTypes.re
+++ b/src/TranslateTypeExprFromTypes.re
@@ -153,10 +153,10 @@ let translateConstr =
     | Path.Papply(_) => raise(ContainsApply)
     };
   let defaultCase = () => {
-    let typeArgs = paramsTranslation |> List.map(({type_, _}) => type_);
+    let typeArgs = paramsTranslation |> List.map(({type_}) => type_);
     let typeParamDeps =
       paramsTranslation
-      |> List.map(({dependencies, _}) => dependencies)
+      |> List.map(({dependencies}) => dependencies)
       |> List.concat;
 
     switch (typeEnv |> TypeEnv.applyTypeEquations(~config, ~path)) {
@@ -390,15 +390,15 @@ let translateConstr =
   | (["Js", "t"], _) =>
     let dependencies =
       fieldsTranslations
-      |> List.map(((_, {dependencies, _})) => dependencies)
+      |> List.map(((_, {dependencies})) => dependencies)
       |> List.concat;
     let rec checkMutableField = (~acc=[], fields) =>
       switch (fields) {
-      | [(previousName, {type_: _, _}), (name, {type_, _}), ...rest]
+      | [(previousName, {type_: _}), (name, {type_}), ...rest]
           when Runtime.checkMutableObjectField(~previousName, ~name) =>
         /* The field was annotated "@bs.set" */
         rest |> checkMutableField(~acc=[(name, type_, Mutable), ...acc])
-      | [(name, {type_, _}), ...rest] =>
+      | [(name, {type_}), ...rest] =>
         rest |> checkMutableField(~acc=[(name, type_, Immutable), ...acc])
       | [] => acc |> List.rev
       };
@@ -571,8 +571,8 @@ and translateTypeExprFromTypes_ =
   | Tvar(Some(s)) => {dependencies: [], type_: TypeVar(s)}
 
   | Tconstr(
-      Pdot(Pident({name: "Js", _}), "t", _) as path,
-      [{desc: Tobject(tObj, _), _}],
+      Pdot(Pident({name: "Js"}), "t", _) as path,
+      [{desc: Tobject(tObj, _)}],
       _,
     ) =>
     let rec getFieldTypes = (texp: Types.type_expr) =>
@@ -610,7 +610,7 @@ and translateTypeExprFromTypes_ =
       ~typeEnv,
     );
 
-  | Tconstr(path, [{desc: Tlink(te), _}], r) =>
+  | Tconstr(path, [{desc: Tlink(te)}], r) =>
     {...typeExpr, desc: Types.Tconstr(path, [te], r)}
     |> translateTypeExprFromTypes_(
          ~config,
@@ -655,10 +655,10 @@ and translateTypeExprFromTypes_ =
     let innerTypesTranslation =
       listExp |> translateTypeExprsFromTypes_(~config, ~typeVarsGen, ~typeEnv);
     let innerTypes =
-      innerTypesTranslation |> List.map(({type_, _}) => type_);
+      innerTypesTranslation |> List.map(({type_}) => type_);
     let innerTypesDeps =
       innerTypesTranslation
-      |> List.map(({dependencies, _}) => dependencies)
+      |> List.map(({dependencies}) => dependencies)
       |> List.concat;
 
     let tupleType = Tuple(innerTypes);
@@ -718,7 +718,7 @@ and translateTypeExprFromTypes_ =
       let type_ = createVariant(~noPayloads, ~payloads, ~polymorphic=true);
       let dependencies =
         payloadTranslations
-        |> List.map(((_, {dependencies, _})) => dependencies)
+        |> List.map(((_, {dependencies})) => dependencies)
         |> List.concat;
       {dependencies, type_};
 
@@ -780,8 +780,8 @@ and signatureToModuleRuntimeRepresentation =
     signature
     |> List.map(signatureItem =>
          switch (signatureItem) {
-         | Types.Sig_value(_id, {val_kind: Val_prim(_), _}) => ([], [])
-         | Types.Sig_value(id, {val_type: typeExpr, _}) =>
+         | Types.Sig_value(_id, {val_kind: Val_prim(_)}) => ([], [])
+         | Types.Sig_value(id, {val_type: typeExpr}) =>
            let {dependencies, type_} =
              typeExpr
              |> translateTypeExprFromTypes_(

--- a/src/Translation.re
+++ b/src/Translation.re
@@ -5,7 +5,7 @@ type t = CodeItem.translation;
 let empty: t = {importTypes: [], codeItems: [], typeDeclarations: []};
 
 let getImportTypeUniqueName =
-    ({typeName, asTypeName, _}: CodeItem.importType) =>
+    ({typeName, asTypeName}: CodeItem.importType) =>
   typeName
   ++ (
     switch (asTypeName) {
@@ -374,14 +374,14 @@ let translatePrimitive =
 
     let (propsFields, childrenTyp) =
       switch (type_) {
-      | Function({argTypes: [propOrChildren, ...childrenOrNil], _}) =>
+      | Function({argTypes: [propOrChildren, ...childrenOrNil]}) =>
         switch (childrenOrNil) {
         | [] => ([], mixedOrUnknown(~config))
         | [children, ..._] =>
           switch (propOrChildren) {
           | GroupOfLabeledArgs(fields) => (
               fields
-              |> List.map(({optional, type_, _} as field) =>
+              |> List.map(({optional, type_} as field) =>
                    switch (type_, optional) {
                    | (Option(type1), Optional) => {
                        ...field,

--- a/src/Translation.re
+++ b/src/Translation.re
@@ -94,7 +94,7 @@ let translateValue =
     )
     : t => {
   let nameAs =
-    switch (Annotation.getAttributeRenaming(attributes)) {
+    switch (Annotation.getGenTypeAsRenaming(attributes)) {
     | Some(s) => s
     | _ => name
     };

--- a/src/TypeVars.re
+++ b/src/TypeVars.re
@@ -5,7 +5,7 @@ let extractFromTypeExpr = typeParams =>
   |> List.fold_left(
        (soFar, typeExpr) =>
          switch (typeExpr) {
-         | {Types.desc: Tvar(Some(s)), _} =>
+         | {Types.desc: Tvar(Some(s))} =>
            let typeName = s;
            [typeName, ...soFar];
          | _ => assert(false)
@@ -93,7 +93,7 @@ let rec free_ = type0: StringSet.t =>
   | Record(fields) =>
     fields
     |> List.fold_left(
-         (s, {type_, _}) => StringSet.union(s, type_ |> free_),
+         (s, {type_}) => StringSet.union(s, type_ |> free_),
          StringSet.empty,
        )
   | Ident({typeArgs}) =>


### PR DESCRIPTION
If `@bs.as` is on a record field, the renamed name should be used in JS. No conversion is required.

See https://github.com/BuckleScript/bucklescript/issues/3979.

Docs should be updated to discourage the use of `@genType.as` for the same purpose (from bs 7.0.0. onwards).