### PR TITLE
Fix issue when emitting optional variants.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,8 @@
 # master
+- Fix issue when emitting optional variants.
+  Variants are `| x | y`, remove the leading `|`.
+  Also, Flow uses ?t, so add parens: `? ( foo | bar)`.
+- Add builtin support for Js.String2.t as string.
 
 # 3.5.0
 - Add support for `@bs.as` to rename record fields (from bukclescript 7.0.0).

--- a/examples/flow-react-example/src/AutoAnnotate.gen.js
+++ b/examples/flow-react-example/src/AutoAnnotate.gen.js
@@ -27,7 +27,7 @@ export type r3 = {| +r3: number |};
 export type r4 = {| +r4: number |};
 
 export type annotatedVariant = 
-  | {| tag: "R2", value: [r2, r3] |}
+    {| tag: "R2", value: [r2, r3] |}
   | {| tag: "R4", value: r4 |};
 
 export type r5 = {| +r5: number |};

--- a/examples/flow-react-example/src/Component2.gen.js
+++ b/examples/flow-react-example/src/Component2.gen.js
@@ -17,7 +17,7 @@ import * as Component2BS from './Component2.bs';
 import * as ReasonReact from 'reason-react/src/ReasonReact.js';
 
 export type variant = 
-  | "A"
+    "A"
   | {| tag: "B", value: [number, number] |}
   | {| tag: "C", value: ?number |};
 

--- a/examples/flow-react-example/src/Types.gen.js
+++ b/examples/flow-react-example/src/Types.gen.js
@@ -41,7 +41,7 @@ import type {variant as AutoAnnotate_variant} from './AutoAnnotate.gen';
 import type {weekday as $$weekday} from './SomeFlowTypes';
 
 export type typeWithVars<x,y,z> = 
-  | {| tag: "A", value: [x, y] |}
+    {| tag: "A", value: [x, y] |}
   | {| tag: "B", value: z |};
 
 export type optionInt = ?number;

--- a/examples/flow-react-example/src/Variants.bs.js
+++ b/examples/flow-react-example/src/Variants.bs.js
@@ -45,6 +45,26 @@ function id2(x) {
   return x;
 }
 
+function polyWithOpt(foo) {
+  var match = foo === "bar";
+  if (match) {
+    return ;
+  } else {
+    var match$1 = foo !== "baz";
+    if (match$1) {
+      return /* `One */[
+              3953222,
+              foo
+            ];
+    } else {
+      return /* `Two */[
+              4203884,
+              1
+            ];
+    }
+  }
+}
+
 var monday = /* monday */-949852400;
 
 var saturday = /* saturday */-29784519;
@@ -70,6 +90,7 @@ export {
   testConvert2to3 ,
   id1 ,
   id2 ,
+  polyWithOpt ,
   
 }
 /* No side effect */

--- a/examples/flow-react-example/src/Variants.gen.js
+++ b/examples/flow-react-example/src/Variants.gen.js
@@ -33,7 +33,7 @@ const $$toRE1061900109 = {"x": 120, "same": 26810};
 import * as VariantsBS from './Variants.bs';
 
 export type weekday = 
-  | "monday"
+    "monday"
   | "tuesday"
   | "wednesday"
   | "thursday"
@@ -50,6 +50,9 @@ export type testGenTypeAs3 = "type" | "module" | "XXX THIS IS DIFFERENT";
 export type x1 = "x" | "same";
 
 export type x2 = "x" | "same";
+
+export type type_ = "type";
+export type type = type_;
 
 export const isWeekend: (weekday) => boolean = function (Arg1: $any) {
   const result = VariantsBS.isWeekend($$toRE288839514[Arg1]);
@@ -104,4 +107,13 @@ export const id1: (x1) => x1 = function (Arg1: $any) {
 export const id2: (x2) => x2 = function (Arg1: $any) {
   const result = VariantsBS.id2($$toRE1061900109[Arg1]);
   return $$toJS1061900109[result]
+};
+
+export const polyWithOpt: (string) => ? (
+    {| tag: "One", value: string |}
+  | {| tag: "Two", value: number |}) = function (Arg1: $any) {
+  const result = VariantsBS.polyWithOpt(Arg1);
+  return (result == null ? result : result[0]===/* One */3953222
+    ? {tag:"One", value:result[1]}
+    : {tag:"Two", value:result[1]})
 };

--- a/examples/flow-react-example/src/Variants.re
+++ b/examples/flow-react-example/src/Variants.re
@@ -90,3 +90,12 @@ let id1 = (x: x1) => x;
 
 [@genType]
 let id2 = (x: x2) => x;
+
+[@genType]
+[@genType.as "type"]
+type type_ =
+  | [@genType.as "type"] Type;
+
+[@genType]
+let polyWithOpt = foo =>
+  foo === "bar" ? None : foo !== "baz" ? Some(`One(foo)) : Some(`Two(1));

--- a/examples/flow-react-example/src/VariantsWithPayload.gen.js
+++ b/examples/flow-react-example/src/VariantsWithPayload.gen.js
@@ -30,14 +30,14 @@ export type payload = {| +x: number, +y?: string |};
 export type withPayload = "a" | "bRenamed" | true | 20 | 0.5 | payload;
 
 export type manyPayloads = 
-  | {| tag: "oneRenamed", value: number |}
+    {| tag: "oneRenamed", value: number |}
   | {| tag: 2, value: [string, string] |}
   | {| tag: "three", value: payload |};
 
 export type simpleVariant = "A" | "B" | "C";
 
 export type variantWithPayloads = 
-  | "ARenamed"
+    "ARenamed"
   | {| tag: "B", value: number |}
   | {| tag: "C", value: [number, number] |}
   | {| tag: "D", value: [number, number] |}

--- a/examples/flow-react-example/src/interop/ImportJsValue.gen.js
+++ b/examples/flow-react-example/src/interop/ImportJsValue.gen.js
@@ -124,7 +124,7 @@ export type stringFunction = $$stringFunction;
 export type color = "tomato" | "gray";
 
 export type variant = 
-  | {| tag: "I", value: number |}
+    {| tag: "I", value: number |}
   | {| tag: "S", value: string |};
 
 export type num = $$num;

--- a/examples/flow-react-example/src/nested/Nested.gen.js
+++ b/examples/flow-react-example/src/nested/Nested.gen.js
@@ -19,7 +19,7 @@ import * as NestedBS from './Nested.bs';
 import type {variant as Component2_variant} from '../../src/Component2.gen';
 
 export type variant = 
-  | "A"
+    "A"
   | {| tag: "B", value: [number, number] |}
   | {| tag: "C", value: ?number |};
 

--- a/examples/typescript-react-example/src/AutoAnnotate.gen.tsx
+++ b/examples/typescript-react-example/src/AutoAnnotate.gen.tsx
@@ -19,5 +19,5 @@ export type r4 = { readonly r4: number };
 
 // tslint:disable-next-line:interface-over-type-literal
 export type annotatedVariant = 
-  | { tag: "R2"; value: [r2, r3] }
+    { tag: "R2"; value: [r2, r3] }
   | { tag: "R4"; value: r4 };

--- a/examples/typescript-react-example/src/ImportJsValue.gen.tsx
+++ b/examples/typescript-react-example/src/ImportJsValue.gen.tsx
@@ -112,7 +112,7 @@ export type color = "tomato" | "gray";
 
 // tslint:disable-next-line:interface-over-type-literal
 export type variant = 
-  | { tag: "I"; value: number }
+    { tag: "I"; value: number }
   | { tag: "S"; value: string };
 
 // tslint:disable-next-line:interface-over-type-literal

--- a/examples/typescript-react-example/src/ReasonComponent.gen.tsx
+++ b/examples/typescript-react-example/src/ReasonComponent.gen.tsx
@@ -34,7 +34,7 @@ export type person<a> = {
 
 // tslint:disable-next-line:interface-over-type-literal
 export type t = 
-  | "A"
+    "A"
   | { tag: "B"; value: number }
   | { tag: "C"; value: string };
 

--- a/examples/typescript-react-example/src/Variants.bs.js
+++ b/examples/typescript-react-example/src/Variants.bs.js
@@ -45,6 +45,26 @@ function id2(x) {
   return x;
 }
 
+function polyWithOpt(foo) {
+  var match = foo === "bar";
+  if (match) {
+    return ;
+  } else {
+    var match$1 = foo !== "baz";
+    if (match$1) {
+      return /* `One */[
+              3953222,
+              foo
+            ];
+    } else {
+      return /* `Two */[
+              4203884,
+              1
+            ];
+    }
+  }
+}
+
 var monday = /* monday */-949852400;
 
 var saturday = /* saturday */-29784519;
@@ -70,6 +90,7 @@ export {
   testConvert2to3 ,
   id1 ,
   id2 ,
+  polyWithOpt ,
   
 }
 /* No side effect */

--- a/examples/typescript-react-example/src/Variants.gen.tsx
+++ b/examples/typescript-react-example/src/Variants.gen.tsx
@@ -29,7 +29,7 @@ const VariantsBS = require('./Variants.bs');
 
 // tslint:disable-next-line:interface-over-type-literal
 export type weekday = 
-  | "monday"
+    "monday"
   | "tuesday"
   | "wednesday"
   | "thursday"
@@ -109,4 +109,13 @@ export const id1: (_1:x1) => x1 = function (Arg1: any) {
 export const id2: (_1:x2) => x2 = function (Arg1: any) {
   const result = VariantsBS.id2($$toRE1061900109[Arg1]);
   return $$toJS1061900109[result]
+};
+
+export const polyWithOpt: (_1:string) => (null | undefined | 
+    { tag: "One"; value: string }
+  | { tag: "Two"; value: number }) = function (Arg1: any) {
+  const result = VariantsBS.polyWithOpt(Arg1);
+  return (result == null ? result : result[0]===/* One */3953222
+    ? {tag:"One", value:result[1]}
+    : {tag:"Two", value:result[1]})
 };

--- a/examples/typescript-react-example/src/Variants.re
+++ b/examples/typescript-react-example/src/Variants.re
@@ -95,3 +95,7 @@ let id2 = (x: x2) => x;
 [@genType.as "type"]
 type type_ =
   | [@genType.as "type"] Type;
+
+[@genType]
+let polyWithOpt = foo =>
+  foo === "bar" ? None : foo !== "baz" ? Some(`One(foo)) : Some(`Two(1));

--- a/examples/typescript-react-example/src/VariantsWithPayload.gen.tsx
+++ b/examples/typescript-react-example/src/VariantsWithPayload.gen.tsx
@@ -28,7 +28,7 @@ export type withPayload = "a" | "bRenamed" | true | 20 | 0.5 | payload;
 
 // tslint:disable-next-line:interface-over-type-literal
 export type manyPayloads = 
-  | { tag: "oneRenamed"; value: number }
+    { tag: "oneRenamed"; value: number }
   | { tag: 2; value: [string, string] }
   | { tag: "three"; value: payload };
 
@@ -37,7 +37,7 @@ export type simpleVariant = "A" | "B" | "C";
 
 // tslint:disable-next-line:interface-over-type-literal
 export type variantWithPayloads = 
-  | "ARenamed"
+    "ARenamed"
   | { tag: "B"; value: number }
   | { tag: "C"; value: [number, number] }
   | { tag: "D"; value: [number, number] }

--- a/examples/typescript-react-example/src/nested/Types.gen.tsx
+++ b/examples/typescript-react-example/src/nested/Types.gen.tsx
@@ -21,7 +21,7 @@ export type t = number;
 
 // tslint:disable-next-line:interface-over-type-literal
 export type typeWithVars<x,y,z> = 
-  | { tag: "A"; value: [x, y] }
+    { tag: "A"; value: [x, y] }
   | { tag: "B"; value: z };
 
 // tslint:disable-next-line:interface-over-type-literal

--- a/src/EmitType.re
+++ b/src/EmitType.re
@@ -229,11 +229,18 @@ let rec renderType =
     switch (config.language) {
     | Flow
     | Untyped =>
+      let isComplex =
+        switch (type_) {
+        | Variant(_) => true
+        | _ => false
+        };
       "?"
+      ++ (isComplex ? " (" : "")
       ++ (
         type_
         |> renderType(~config, ~indent, ~typeNameIsInterface, ~inFunType)
       )
+      ++ (isComplex ? ")" : "");
     | TypeScript =>
       "(null | undefined | "
       ++ (
@@ -298,10 +305,13 @@ let rec renderType =
          });
     let rendered = noPayloadsRendered @ payloadsRendered;
     let indent1 = rendered |> Indent.heuristicVariants(~indent);
-    (indent1 == None ? rendered : ["", ...rendered])
-    |> String.concat(
-         (indent1 == None ? " " : Indent.break(~indent=indent1)) ++ "| ",
-       );
+    (indent1 == None ? "" : Indent.break(~indent=indent1) ++ "  ")
+    ++ (
+      rendered
+      |> String.concat(
+           (indent1 == None ? " " : Indent.break(~indent=indent1)) ++ "| ",
+         )
+    );
   }
 and renderField =
     (


### PR DESCRIPTION
Variants are emitted as `| x | y`, remove the leading `|`.
Also, Flow uses `?t`, so add parens: `? (foo | bar)`.

Fixes https://github.com/cristianoc/genType/issues/326.