### PR TITLE
Fix issues where `@genType.as` on a type definition would omit type p…

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,5 @@
 # master
+- Fix issues where `@genType.as` on a type definition would omit type parameters.
 
 # 3.9.0
 - With TypeScript back-end, emit import of React when function components are exported.

--- a/examples/typescript-react-example/src/nested/Types.gen.tsx
+++ b/examples/typescript-react-example/src/nested/Types.gen.tsx
@@ -91,6 +91,10 @@ export type someRecord = { readonly id: number };
 // tslint:disable-next-line:interface-over-type-literal
 export type instantiateTypeParameter = ocaml_array<someRecord>;
 
+// tslint:disable-next-line:interface-over-type-literal
+export type vector<a> = [a, a];
+export type Vector<a> = vector<a>;
+
 export const someIntList: list<number> = TypesBS.someIntList;
 
 export const map: <T1,T2>(_1:((_1:T1) => T2), _2:list<T1>) => list<T2> = function <T1,T2>(Arg1: any, Arg2: any) {

--- a/examples/typescript-react-example/src/nested/Types.re
+++ b/examples/typescript-react-example/src/nested/Types.re
@@ -146,3 +146,7 @@ type instantiateTypeParameter = ocaml_array(someRecord);
 
 [@genType]
 let testInstantiateTypeParameter = (x: instantiateTypeParameter) => x;
+
+[@genType]
+[@genType.as "Vector"]
+type vector('a) = ('a, 'a);

--- a/src/EmitType.re
+++ b/src/EmitType.re
@@ -524,7 +524,14 @@ let emitExportType =
   let exportNameAs =
     switch (nameAs) {
     | None => ""
-    | Some(s) => "\nexport type " ++ s ++ " = " ++ resolvedTypeName ++ ";"
+    | Some(s) =>
+      "\nexport type "
+      ++ s
+      ++ typeParamsString
+      ++ " = "
+      ++ resolvedTypeName
+      ++ typeParamsString
+      ++ ";"
     };
 
   switch (config.language) {


### PR DESCRIPTION
…arameters.

Fixes https://github.com/cristianoc/genType/issues/347.