### PR TITLE
[dce] Add support for whitelist and blacklist results.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,6 @@
 # master
 - Support new internal representation of `bs.meth` used in the forthcoming bucklescript 7.2.0.
+- Experimental global dead code/type analysis with `-dce` and `-dce-cmt` for bucklescript and native projects respectively.
 
 # 3.12.0
 - Emit doc commments `/** this is a doc comment */` in the TypeScript output.

--- a/examples/typescript-react-example/package.json
+++ b/examples/typescript-react-example/package.json
@@ -16,7 +16,7 @@
     "ts:watch": "react-scripts start",
     "build": "node ../run_bsb.js -make-world",
     "clean": "node ../clean_bsb.js",
-    "dce": "Debug=1 Whitelist=src ../gentype.exe -dce >deadcode.txt",
+    "dce": "Debug=1 Whitelist=src Blacklist=src/DeadTestWhitelist.re ../gentype.exe -dce >deadcode.txt",
     "eject": "react-scripts eject",
     "tsc": "tsc -p tsconfig.json"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "node ./scripts/run_integration_tests.js",
     "install:examples": "(cd examples/typescript-react-example && npm install) & (cd examples/flow-react-example && npm install) & (cd examples/untyped-react-example && npm install) & (cd examples/commonjs-react-example && npm install)",
     "build:examples": "(cd examples/typescript-react-example && npm run clean && npm run build && cd use-some-library && npm run clean && npm run build) && (cd examples/flow-react-example && npm run clean && npm run build) & (cd examples/untyped-react-example && npm run clean && npm run build) & (cd examples/commonjs-react-example && npm run clean && npm run build)",
-    "dce": "./examples/gentype.exe -dce-cmt `find  _esy/default/store/b/gentype-*/default/src/.GenType.eobjs -name byte`",
+    "dce": "Whitelist=src Blacklist=src/nothing ./examples/gentype.exe -dce-cmt `find  _esy/default/store/b/gentype-*/default/src/.GenType.eobjs -name byte`",
     "preversion": "npm test",
     "version": "node scripts/bump_version_module.js && git add -A src/",
     "postversion": "git push && git push --tags"


### PR DESCRIPTION
If environment variable Whtelist=prefix is specified, only report on files having prefix in the path.
If environment variable Blacklist=prefix is specified, don't report on files having prefix in the path.